### PR TITLE
Include availability for records without items

### DIFF
--- a/spec/controllers/availability_controller_spec.rb
+++ b/spec/controllers/availability_controller_spec.rb
@@ -4,32 +4,11 @@ require 'json'
 RSpec.describe AvailabilityController, :type => :controller do
 
   describe 'bib availability hash' do
-    it "each bib id provided is a key in the availability hash, each id value has a more_holdings key" do
-      id_params = ['123','456', '789']
-      get :index, ids: id_params, format: :json
-      availability = JSON.parse(response.body)
-      id_params.each do |id|
-        expect(availability).to include(id)
-        expect(availability[id]).to include('more_holdings')
-      end
-    end
-
-    it 'more_holdings is false when there are two or less holdings' do
-      bib_2_holdings = '8217104'
-      bib_1_holding = '35345'
-      get :index, ids: [bib_2_holdings, bib_1_holding], format: :json
-      availability = JSON.parse(response.body)
-      expect(availability[bib_2_holdings]['more_holdings']).to eq(false)
-      expect(availability[bib_1_holding]['more_holdings']).to eq(false)
-    end
-
-    it 'provides availability for only the first 2 holdings, when more_holdings is true' do
+    it 'provides availability for only the first 2 holdings' do
       bib_3_holdings = '929437'
       get :index, ids: [bib_3_holdings], format: :json
       availability = JSON.parse(response.body)
       bib_availability = availability[bib_3_holdings]
-      expect(availability[bib_3_holdings]['more_holdings']).to eq(true)
-      availability[bib_3_holdings].delete('more_holdings')
       holding_locations = bib_availability.each_value.map { |holding| holding['location'] }
       expect(holding_locations).to include('rcppa')
       expect(holding_locations).to include('fnc')

--- a/voyager_helpers/lib/voyager_helpers/liberator.rb
+++ b/voyager_helpers/lib/voyager_helpers/liberator.rb
@@ -165,7 +165,6 @@ module VoyagerHelpers
       # @return [Hash] :bib_id_value => [Hash] bib availability
       #
       # Bib availability hash:
-      # :more_holdings => [Boolean] Does the bib have more than 2 holdings?
       # For the bib's first 2 holding records:
       # :holding_id_value => [Hash] holding availability
       #
@@ -179,8 +178,6 @@ module VoyagerHelpers
           bibs.each do |bib_id|
             availability[bib_id] = {}
             mfhds = get_holding_records(bib_id, c)
-            availability[bib_id][:more_holdings] = mfhds.count > 2
-
             mfhds[0..1].each do |mfhd| # for the first 2 holdings
               mfhd_hash = mfhd.to_hash
               mfhd_id = id_from_mfhd_hash(mfhd_hash)


### PR DESCRIPTION
Changed the availability service api to include availability for each holding_id rather than location code. Advances #40 
Example:
![updated_availability_api](https://cloud.githubusercontent.com/assets/4650153/11159594/35684fa4-8a2f-11e5-9e4e-d756ff86ed0f.png)
