### PR TITLE
include holding id with holding record fields

### DIFF
--- a/spec/requests/bib_gets_spec.rb
+++ b/spec/requests/bib_gets_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'marc'
 
 RSpec.describe "Bibliographic Gets", :type => :request do
   describe "GET /bibliographic/430472/items" do
@@ -41,4 +42,36 @@ RSpec.describe "Bibliographic Gets", :type => :request do
     end
   end
 
+  describe 'merges 852s and 856s from holding record into bib record' do
+    before(:all) do
+      get '/bibliographic/7617477.json'
+      @ipad_bib_record = JSON.parse(response.body)
+    end
+
+    it 'bib includes firestone holding record info coupled with holding id' do
+      f_holding_id = '7429805'
+      get "/holdings/#{f_holding_id}.json"
+      holding = JSON.parse(response.body)
+      holding = MARC::Record.new_from_hash(holding)
+      eight52 = holding['852'].to_hash
+      eight52['852']['subfields'] << {"0"=>f_holding_id}
+      eight56 = holding['856'].to_hash
+      eight56['856']['subfields'] << {"0"=>f_holding_id}
+      expect(@ipad_bib_record['fields']).to include(eight52)
+      expect(@ipad_bib_record['fields']).to include(eight56)
+    end
+
+    it 'bib includes lewis holding record info coupled with holding id' do
+      sci_holding_id = '7429809'
+      get "/holdings/#{sci_holding_id}.json"
+      holding = JSON.parse(response.body)
+      holding = MARC::Record.new_from_hash(holding)
+      eight52 = holding['852'].to_hash
+      eight52['852']['subfields'] << {"0"=>sci_holding_id}
+      eight56 = holding['856'].to_hash
+      eight56['856']['subfields'] << {"0"=>sci_holding_id}
+      expect(@ipad_bib_record['fields']).to include(eight52)
+      expect(@ipad_bib_record['fields']).to include(eight56)
+    end
+  end
 end

--- a/voyager_helpers/lib/voyager_helpers/liberator.rb
+++ b/voyager_helpers/lib/voyager_helpers/liberator.rb
@@ -414,13 +414,18 @@ module VoyagerHelpers
         end
       end
 
-      # Removes bibliographic 852s, adds holdings 852s, and 959 catalog date
+      # Removes bib 852s, adds holdings 852s and 856s, and 959 catalog date
       def merge_holdings_into_bib(bib, holdings, conn=nil)
         record_hash = bib.to_hash
         record_hash['fields'].delete_if { |f| f.has_key?('852') }
         unless holdings.empty?
           holdings.each do |holding|
             holding.to_hash['fields'].select { |h| h.has_key?('852') }.each do |h|
+              h['852']['subfields'] << {"0"=>holding['001'].value}
+              record_hash['fields'] << h
+            end
+            holding.to_hash['fields'].select { |h| h.has_key?('856') }.each do |h|
+              h['856']['subfields'] << {"0"=>holding['001'].value}
               record_hash['fields'] << h
             end
           end


### PR DESCRIPTION
Closes #49 
I'd like to have a full Voyager dump completed before I'm back in office with this new subfield $0 so we can index the holding id with the holding block info in solr (which will allow Orangelight to consume the new availability API in #48).