### PR TITLE
retrieve all holdings when single bib given

### DIFF
--- a/app/controllers/availability_controller.rb
+++ b/app/controllers/availability_controller.rb
@@ -1,13 +1,21 @@
 class AvailabilityController < ApplicationController
-
   def index
     if params[:ids]
-      record = VoyagerHelpers::Liberator.get_availability(sanitize_array(params[:ids]))
-      if record.empty?
-        render plain: "Item(s): #{params[:ids]} not found.", status: 404
+      avail = VoyagerHelpers::Liberator.get_availability(sanitize_array(params[:ids]))
+      if avail.empty?
+        render plain: "Record(s): #{params[:ids]} not found.", status: 404
       else
         respond_to do |wants|
-          wants.json  { render json: MultiJson.dump(record) }
+          wants.json  { render json: MultiJson.dump(avail) }
+        end
+      end
+    elsif params[:id]
+      avail = VoyagerHelpers::Liberator.get_availability([sanitize(params[:id])], true)
+      if avail.empty?
+        render plain: "Record: #{params[:id]} not found.", status: 404
+      else
+        respond_to do |wants|
+          wants.json  { render json: MultiJson.dump(avail) }
         end
       end
     else
@@ -15,6 +23,3 @@ class AvailabilityController < ApplicationController
     end
   end
 end
-
-
-

--- a/spec/controllers/availability_controller_spec.rb
+++ b/spec/controllers/availability_controller_spec.rb
@@ -4,7 +4,7 @@ require 'json'
 RSpec.describe AvailabilityController, :type => :controller do
 
   describe 'bib availability hash' do
-    it 'provides availability for only the first 2 holdings' do
+    it 'provides availability for only the first 2 holdings by default' do
       bib_3_holdings = '929437'
       get :index, ids: [bib_3_holdings], format: :json
       availability = JSON.parse(response.body)
@@ -13,6 +13,16 @@ RSpec.describe AvailabilityController, :type => :controller do
       expect(holding_locations).to include('rcppa')
       expect(holding_locations).to include('fnc')
       expect(holding_locations).not_to include('anxb')
+    end
+
+    it 'provides availability for all holdings if full availability requested' do
+      bib_3_holdings = '929437'
+      get :index, id: bib_3_holdings, format: :json
+      availability = JSON.parse(response.body)
+      holding_locations = availability.each_value.map { |holding| holding['location'] }
+      expect(holding_locations).to include('rcppa')
+      expect(holding_locations).to include('fnc')
+      expect(holding_locations).to include('anxb')
     end
   end
 


### PR DESCRIPTION
When you make an api call in the form of `/availability?id=4679943` all of the holdings are retrieved. Only the first item is currently retrieved. The response looks like this:
![full_avail](https://cloud.githubusercontent.com/assets/4650153/11576094/71aea086-99e2-11e5-954c-f53929f6338f.png)