### PR TITLE
include received on-order pos, on-site access update

### DIFF
--- a/spec/controllers/availability_controller_spec.rb
+++ b/spec/controllers/availability_controller_spec.rb
@@ -46,16 +46,23 @@ RSpec.describe AvailabilityController, :type => :controller do
       expect(availability[bib_online][holding_id]['status']).to eq('Online')
     end
 
-    it 'on-order records have a status of requestable' do
-      bib_on_order = '9160439'
-      holding_id = '9040953'
+    it 'on-order records have a status of On-Order' do
+      bib_on_order = '9173362'
+      holding_id = '9051785'
       get :index, ids: [bib_on_order], format: :json
       availability = JSON.parse(response.body)
-      expect(availability[bib_on_order][holding_id]['status']).to eq('Requestable')
+      expect(availability[bib_on_order][holding_id]['status']).to include('On-Order')
     end
 
-    it 'non open locations have a status of limited' do
-      allow(VoyagerHelpers::Liberator).to receive(:closed_holding_location?).and_return(true)
+    it 'Received on-order records have a status of Order Received' do
+      bib_received_order = '9468468'
+      get :index, id: bib_received_order, format: :json
+      availability = JSON.parse(response.body)
+      expect(availability.first[1]['status']).to include('Order Received')
+    end
+
+    it 'always_requestable locations have a status of limited' do
+      allow(VoyagerHelpers::Liberator).to receive(:limited_access_location?).and_return(true)
       bible = '4609321'
       holding_id = '4847980'
       get :index, ids: [bible], format: :json

--- a/spec/requests/bib_gets_spec.rb
+++ b/spec/requests/bib_gets_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Bibliographic Gets", :type => :request do
     end
 
     it 'does not add item create_date when bib without items is not elf' do
-      get '/bibliographic/9160439.json'
+      get '/bibliographic/4609321.json'
       bib = JSON.parse(response.body)
       has_959 = bib["fields"].any? {|f| f.has_key?('959')}
       expect(has_959).to be(false)

--- a/voyager_helpers/lib/voyager_helpers/queries.rb
+++ b/voyager_helpers/lib/voyager_helpers/queries.rb
@@ -55,22 +55,27 @@ module VoyagerHelpers
       end
 
       def approved_orders(bib_id)
-        # what could go wrong?
-        line_item_status_approved=8
-        po_status_approved=1
+        po_approved=1
+        po_rec_partial=3
+        po_rec_complete=4
+        li_rec_complete=1
+        li_approved=8
+        li_rec_partial=9
         %Q(
-        SELECT bib_text.bib_id, 
-          purchase_order.po_status,
-          line_item_copy_status.line_item_status,
-          line_item_copy_status.status_date
-        FROM ((purchase_order
-        INNER JOIN line_item ON purchase_order.po_id = line_item.po_id)
-        INNER JOIN bib_text ON line_item.bib_id = bib_text.bib_id)
-        INNER JOIN line_item_copy_status ON line_item.line_item_id = line_item_copy_status.line_item_id
-        WHERE (((bib_text.bib_id)=#{bib_id})
-        AND ((purchase_order.po_status)=#{po_status_approved}))
-        OR (((bib_text.bib_id)=#{bib_id})
-        AND ((line_item_copy_status.line_item_status)=#{line_item_status_approved}))
+        SELECT LINE_ITEM.BIB_ID,
+          PURCHASE_ORDER.PO_STATUS,
+          LINE_ITEM_COPY_STATUS.LINE_ITEM_STATUS,
+          LINE_ITEM_COPY_STATUS.STATUS_DATE
+        FROM ((PURCHASE_ORDER
+        INNER JOIN LINE_ITEM ON PURCHASE_ORDER.PO_ID = LINE_ITEM.PO_ID)
+        INNER JOIN LINE_ITEM_COPY_STATUS ON LINE_ITEM.LINE_ITEM_ID = LINE_ITEM_COPY_STATUS.LINE_ITEM_ID)
+        WHERE (LINE_ITEM.BIB_ID = #{bib_id})
+        AND (PURCHASE_ORDER.PO_STATUS = #{po_approved}
+          OR PURCHASE_ORDER.PO_STATUS = #{po_rec_partial}
+          OR PURCHASE_ORDER.PO_STATUS = #{po_rec_complete}
+          OR LINE_ITEM_COPY_STATUS.LINE_ITEM_STATUS = #{li_rec_complete}
+          OR LINE_ITEM_COPY_STATUS.LINE_ITEM_STATUS = #{li_approved}
+          OR LINE_ITEM_COPY_STATUS.LINE_ITEM_STATUS = #{li_rec_partial})
         )
       end
 


### PR DESCRIPTION
 - Include status code when retrieving on-order items. Expand "approved records" to also include partially and completely received orders. Attempts to address #47. 
 - Update availability API to distinguish between "On-Order" and "Order Received" when item record is lacking.
 - always_requestable locations (like rare books) should always have "on-site access" availability regardless of the item status message (if any). Closes #40.
