### PR TITLE
allow all orders to be returned in items response

### DIFF
--- a/spec/controllers/availability_controller_spec.rb
+++ b/spec/controllers/availability_controller_spec.rb
@@ -52,7 +52,6 @@ RSpec.describe AvailabilityController, :type => :controller do
       holding_id = '4847980'
       get :index, ids: [bible], format: :json
       availability = JSON.parse(response.body)
-      puts availability
       expect(availability[bible][holding_id]['status']).to eq('Limited')
     end
 

--- a/spec/controllers/availability_controller_spec.rb
+++ b/spec/controllers/availability_controller_spec.rb
@@ -46,21 +46,6 @@ RSpec.describe AvailabilityController, :type => :controller do
       expect(availability[bib_online][holding_id]['status']).to eq('Online')
     end
 
-    it 'on-order records have a status of On-Order' do
-      bib_on_order = '9173362'
-      holding_id = '9051785'
-      get :index, ids: [bib_on_order], format: :json
-      availability = JSON.parse(response.body)
-      expect(availability[bib_on_order][holding_id]['status']).to include('On-Order')
-    end
-
-    it 'Received on-order records have a status of Order Received' do
-      bib_received_order = '9468468'
-      get :index, id: bib_received_order, format: :json
-      availability = JSON.parse(response.body)
-      expect(availability.first[1]['status']).to include('Order Received')
-    end
-
     it 'always_requestable locations have a status of limited' do
       allow(VoyagerHelpers::Liberator).to receive(:limited_access_location?).and_return(true)
       bible = '4609321'

--- a/voyager_helpers/lib/voyager_helpers/queries.rb
+++ b/voyager_helpers/lib/voyager_helpers/queries.rb
@@ -54,13 +54,7 @@ module VoyagerHelpers
         )
       end
 
-      def approved_orders(bib_id)
-        po_approved=1
-        po_rec_partial=3
-        po_rec_complete=4
-        li_rec_complete=1
-        li_approved=8
-        li_rec_partial=9
+      def orders(bib_id)
         %Q(
         SELECT LINE_ITEM.BIB_ID,
           PURCHASE_ORDER.PO_STATUS,
@@ -70,12 +64,6 @@ module VoyagerHelpers
         INNER JOIN LINE_ITEM ON PURCHASE_ORDER.PO_ID = LINE_ITEM.PO_ID)
         INNER JOIN LINE_ITEM_COPY_STATUS ON LINE_ITEM.LINE_ITEM_ID = LINE_ITEM_COPY_STATUS.LINE_ITEM_ID)
         WHERE (LINE_ITEM.BIB_ID = #{bib_id})
-        AND (PURCHASE_ORDER.PO_STATUS = #{po_approved}
-          OR PURCHASE_ORDER.PO_STATUS = #{po_rec_partial}
-          OR PURCHASE_ORDER.PO_STATUS = #{po_rec_complete}
-          OR LINE_ITEM_COPY_STATUS.LINE_ITEM_STATUS = #{li_rec_complete}
-          OR LINE_ITEM_COPY_STATUS.LINE_ITEM_STATUS = #{li_approved}
-          OR LINE_ITEM_COPY_STATUS.LINE_ITEM_STATUS = #{li_rec_partial})
         )
       end
 

--- a/voyager_helpers/spec/unit/voyager_helpers/liberator_spec.rb
+++ b/voyager_helpers/spec/unit/voyager_helpers/liberator_spec.rb
@@ -6,7 +6,7 @@ describe VoyagerHelpers::Liberator do
   let(:date) { Date.parse("2015-12-14T15:34:00.000-05:00") }
   let(:no_order_found) { {} }
   let(:pre_order) { [{
-                      date: Date.parse("2015-12-17T15:34:00.000-05:00"),
+                      date: nil,
                       li_status: 0,
                       po_status: 0
                       }] }
@@ -32,9 +32,9 @@ describe VoyagerHelpers::Liberator do
       allow(described_class).to receive(:get_orders).and_return(no_order_found)
       expect(described_class.get_order_status(placeholder_bib)).to eq nil
     end
-    it 'returns nil for pending orders' do
+    it 'returns Pending Order for pending orders, date not included if nil' do
       allow(described_class).to receive(:get_orders).and_return(pre_order)
-      expect(described_class.get_order_status(placeholder_bib)).to eq nil
+      expect(described_class.get_order_status(placeholder_bib)).to eq "Pending Order"
     end
     it 'returns On-Order for approved order' do
       allow(described_class).to receive(:get_orders).and_return(approved_order)

--- a/voyager_helpers/spec/unit/voyager_helpers/liberator_spec.rb
+++ b/voyager_helpers/spec/unit/voyager_helpers/liberator_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+describe VoyagerHelpers::Liberator do
+
+  let(:placeholder_bib) { 12345 }
+  let(:date) { Date.parse("2015-12-14T15:34:00.000-05:00") }
+  let(:no_order_found) { {} }
+  let(:pre_order) { [{
+                      date: Date.parse("2015-12-17T15:34:00.000-05:00"),
+                      li_status: 0,
+                      po_status: 0
+                      }] }
+  let(:approved_order) { [{
+                      date: date,
+                      li_status: 8,
+                      po_status: 1
+                      }] }
+  let(:partially_rec_order) { [{
+                      date: Date.parse("2015-12-16T15:34:00.000-05:00"),
+                      li_status: 8,
+                      po_status: 3
+                      }] }
+  let(:received_order) { [{
+                      date: Date.parse("2015-12-15T15:34:00.000-05:00"),
+                      li_status: 1,
+                      po_status: 4
+                      }] }
+
+  describe '#get_order_status' do
+
+    it 'returns nil when no order found for bib' do
+      allow(described_class).to receive(:get_orders).and_return(no_order_found)
+      expect(described_class.get_order_status(placeholder_bib)).to eq nil
+    end
+    it 'returns nil for pending orders' do
+      allow(described_class).to receive(:get_orders).and_return(pre_order)
+      expect(described_class.get_order_status(placeholder_bib)).to eq nil
+    end
+    it 'returns On-Order for approved order' do
+      allow(described_class).to receive(:get_orders).and_return(approved_order)
+      expect(described_class.get_order_status(placeholder_bib)).to include('On-Order')
+    end
+    it 'returns On-Order for partially received order' do
+      allow(described_class).to receive(:get_orders).and_return(partially_rec_order)
+      expect(described_class.get_order_status(placeholder_bib)).to include('On-Order')
+    end
+    it 'returns Order Received for fully received order' do
+      allow(described_class).to receive(:get_orders).and_return(received_order)
+      expect(described_class.get_order_status(placeholder_bib)).to include('Order Received')
+    end
+    it "includes status date with order response" do
+      allow(described_class).to receive(:get_orders).and_return(approved_order)
+      expect(described_class.get_order_status(placeholder_bib)).to include(date.strftime('%m-%d-%Y'))
+    end
+  end
+end


### PR DESCRIPTION
 - It's useful to figure out on-order information for all bibs that don't have item records. I changed the "approved_orders" query to return the on-order info regardless of approval status. The order statuses appear when requesting a bib's item record (mainly for debugging). Closes #47.

 -  The availability API will prune out non-approved orders. Although we might want to consider including pending records, as they are included in the Voyager OPAC. See #53. 
