### PR TITLE
ignore some of the item statuses

### DIFF
--- a/voyager_helpers/lib/voyager_helpers/queries.rb
+++ b/voyager_helpers/lib/voyager_helpers/queries.rb
@@ -45,7 +45,8 @@ module VoyagerHelpers
             ON mfhd_item.item_id = item.item_id
           LEFT JOIN item_barcode
             ON item_barcode.item_id = item.item_id
-        WHERE item.item_id=#{item_id}
+        WHERE item.item_id=#{item_id} AND
+          item_status.item_status NOT IN ('5', '6', '16', '19', '20', '21', '23', '24')
         )
       end
 
@@ -63,7 +64,8 @@ module VoyagerHelpers
             ON item_status.item_id = item.item_id
           INNER JOIN item_status_type
             ON item_status_type.item_status_type = item_status.item_status
-        WHERE item.item_id=#{item_id}
+        WHERE item.item_id=#{item_id} AND
+          item_status.item_status NOT IN ('5', '6', '16', '19', '20', '21', '23', '24')
         )
       end
 


### PR DESCRIPTION
Items can have multiple statuses assigned. The bibdata item service only takes the last one it finds, which is problematic for this [item](https://bibdata.princeton.edu/items/2645372) from [Science](https://pulsearch-dev.princeton.edu/catalog/857469). It has a status of 1 (Not Charged) and 19 (Cataloging Review). Some status codes are now ignored with this PR such that the item service will return Not Charged instead of Cataloging Review.