### PR TITLE
temp location display text in availability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :development, :production do
   gem 'ruby-oci8', '~> 2.2.1'
 end
 
-gem 'voyager_helpers', git: 'git@github.com:pulibrary/voyager_helpers.git', :tag => 'v0.1.0'
+gem 'voyager_helpers', git: 'git@github.com:pulibrary/voyager_helpers.git', :tag => 'v0.1.1'
 
 gem 'responders', '~> 2.0'
 gem 'marc', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,10 +12,10 @@ GIT
 
 GIT
   remote: git@github.com:pulibrary/voyager_helpers.git
-  revision: 2398c8c037867e3b818a1089755b5a033b2ae5e5
-  tag: v0.1.0
+  revision: f075096f6657e3174432f16b835cb656098223d9
+  tag: v0.1.1
   specs:
-    voyager_helpers (0.1.0)
+    voyager_helpers (0.1.1)
       activesupport (~> 4.1)
       diffy (~> 3.0.7)
       marc (~> 1.0)


### PR DESCRIPTION
Item temporary location codes are converted to their full location display text with library and holding location label (if not blank) in the availability service. This will allow Blacklight to display on-reserve locations in the search results and record show view.