### PR TITLE
Index updates 52616

### DIFF
--- a/marc_to_solr/lib/format/bib_format.rb
+++ b/marc_to_solr/lib/format/bib_format.rb
@@ -19,8 +19,6 @@ class BibFormat
       if record['502']['a']
         if (record['502']['a'].include? "(Senior)--Princeton University") || (record['502']['a'].include? "Thesis (Senior)-Princeton University")
           @code << "ST"
-        else
-          @code << "TH"
         end
       end
     end

--- a/marc_to_solr/lib/princeton_marc.rb
+++ b/marc_to_solr/lib/princeton_marc.rb
@@ -437,7 +437,7 @@ def process_holdings record
     holding['call_number_browse'] = holding['call_number_browse'].join(' ') if holding['call_number_browse']
     all_holdings[holding_id] = holding unless holding_id.nil?
   end
-  Traject::MarcExtractor.cached('866| 0|0az:866| 1|0az:866| 2|0az:866|30|0az:866|31|0az:866|32|0az:866|40|0az:866|41|0az:866|42|0az:866|50|0az:866|51|0az:866|52|0az').collect_matching_lines(record) do |field, spec, extractor|
+  Traject::MarcExtractor.cached('866az').collect_matching_lines(record) do |field, spec, extractor|
     value = []
     holding_id = nil
     field.subfields.each do |s_field|
@@ -452,23 +452,6 @@ def process_holdings record
     if (all_holdings[holding_id] and !value.empty?)
       all_holdings[holding_id]['location_has'] ||= []
       all_holdings[holding_id]['location_has'] << value.join(' ')
-    end
-  end
-  Traject::MarcExtractor.cached('866|  |0az').collect_matching_lines(record) do |field, spec, extractor|
-    value = []
-    holding_id = nil
-    field.subfields.each do |s_field|
-      if s_field.code == '0'
-        holding_id = s_field.value
-      elsif s_field.code == 'a'
-        value << s_field.value
-      elsif s_field.code == 'z'
-        value << s_field.value
-      end
-    end
-    if (all_holdings[holding_id] and !value.empty?)
-      all_holdings[holding_id]['location_has_current'] ||= []
-      all_holdings[holding_id]['location_has_current'] << value.join(' ')
     end
   end
   Traject::MarcExtractor.cached('8670az').collect_matching_lines(record) do |field, spec, extractor|

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -755,7 +755,7 @@ to_field 'constituent_part_display', extract_marc('774abcdghikmnrstu')
 
 # ISBN:
 #    020 XX a
-to_field 'isbn_display', extract_marc('020a')
+to_field 'isbn_display', extract_marc('020aq')
 
 # ISSN:
 #    022 XX a

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -84,6 +84,7 @@ to_field 'uniform_title_s', extract_marc('100t:110t:111t:130apldfhkmnorst:240apl
 #    245 XX abchknps
 to_field 'title_display', extract_marc('245abcfghknps', :alternate_script => false)
 
+to_field 'title_a_index', extract_marc('245a')
 
 to_field 'title_vern_display', extract_marc('245abcfghknps', :alternate_script => :only)
 to_field 'cjk_title', extract_marc('245abcfghknps', :alternate_script => :only)

--- a/marc_to_solr/spec/fixtures/sample27.mrx
+++ b/marc_to_solr/spec/fixtures/sample27.mrx
@@ -42,6 +42,11 @@
     <datafield ind1=" " ind2="0" tag="650">
       <subfield code="a">Drawing, Italian.</subfield>
     </datafield>
+    <datafield ind1="" ind2=" " tag="700">
+      <subfield code="a">Someone</subfield>
+      <subfield code="e">editor</subfield>
+      <subfield code="e">painter</subfield>
+    </datafield>
     <datafield ind1="2" ind2=" " tag="710">
       <subfield code="a">Biblioteca ambrosiana.</subfield>
       <subfield code="k">Mss.</subfield>

--- a/marc_to_solr/spec/lib/config_spec.rb
+++ b/marc_to_solr/spec/lib/config_spec.rb
@@ -60,9 +60,13 @@ describe 'From traject_config.rb' do
     end
   end
   describe 'related_name_json_1display' do
+    let(:rel_names) { JSON.parse(@related_names['related_name_json_1display'][0]) }
     it 'trims punctuation the same way as author_s facet' do
-      rel_names = JSON.parse(@related_names['related_name_json_1display'][0])
       rel_names['Related name'].each {|n| expect(@related_names['author_s']).to include(n)}
+    end
+    it 'allows multiple roles from single field' do
+      expect(rel_names['Editor']).to include('Someone')
+      expect(rel_names['Painter']).to include('Someone')
     end
   end
   describe 'access_facet' do

--- a/marc_to_solr/spec/lib/format_spec.rb
+++ b/marc_to_solr/spec/lib/format_spec.rb
@@ -23,4 +23,23 @@ describe 'From format.rb' do
       end
     end
   end
+
+  describe '502 note' do
+    let(:senior_thesis_502) { {"502"=>{"ind1"=>" ","ind2"=>" ","subfields"=>[{"a"=>"Thesis (Senior)-Princeton University"}]}} }
+    let(:senior_thesis_marc) { MARC::Record.new_from_hash({ 'fields' => [senior_thesis_502] }) }
+    let(:dissertation_502) { {"502"=>{"ind1"=>" ","ind2"=>" ","subfields"=>[{"a"=>"Not a senior thesis"}]}} }
+    let(:dissertation_marc) { MARC::Record.new_from_hash({ 'fields' => [dissertation_502] }) }
+
+    it 'Princeton senior theses are properly classified' do
+      senior_thesis_marc.leader = marc.leader
+      puts senior_thesis_marc.leader
+      fmt = Format.new(senior_thesis_marc).bib_format
+      expect(Traject::TranslationMap.new("format").translate_array!(fmt)).to include 'Senior Thesis'
+    end
+    it 'Other dissertations are not assigned a separate format' do
+      dissertation_marc.leader = marc.leader
+      fmt = Format.new(dissertation_marc).bib_format
+      expect(Traject::TranslationMap.new("format").translate_array!(fmt)).not_to include 'Dissertation'
+    end
+  end
 end

--- a/marc_to_solr/spec/lib/princeton_marc_spec.rb
+++ b/marc_to_solr/spec/lib/princeton_marc_spec.rb
@@ -370,12 +370,9 @@ describe 'From princeton_marc.rb' do
       expect(@holding_block[@oversize_mfhd_id]['call_number']).to eq("Oversize #{@call_number}")
     end
 
-    it 'location_has takes from 866 $a and $z when the 1st ind is blank or 3-5 and 2nd ind is 0-2' do
-      expect(@holding_block[@oversize_mfhd_id]['location_has']).to include("volume 1 full", "In reading room")
-    end
-    it 'location_has_current takes from 866 $a and $z when both indicators are blank' do
-      expect(@holding_block[@oversize_mfhd_id]['location_has_current']).to include("v2 available")
-      expect(@holding_block[@other_mfhd_id]['location_has_current']).to include("v4 p3")
+    it 'location_has takes from 866 $a and $z regardless of indicators' do
+      expect(@holding_block[@oversize_mfhd_id]['location_has']).to include("volume 1 full", "In reading room", "v2 available")
+      expect(@holding_block[@other_mfhd_id]['location_has']).to include("v4 p3")
     end
     it 'supplements takes from 867 $a and $z' do
       expect(@holding_block[@other_mfhd_id]['supplements']).to include("v454")


### PR DESCRIPTION
 - All 866s fields are included in the location_has holding field. Closes #91 and closes pulibrary/orangelight#542.
 - Removes dissertation facet. Closes pulibrary/orangelight#506.
 - Adds subfields $q to the isbn_display field. Closes #122 
 - Adds a title field that only includes 245 subfield $a. Advances pulibrary/orangelight#518.
 - Name fields can have multiple roles. Closes pulibrary/orangelight#530.