### PR TITLE
Advance voyager_helpers to 0.2.0. Add route for patron stat codes lookup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :development, :production do
   gem 'ruby-oci8', '~> 2.2.1'
 end
 
-gem 'voyager_helpers', git: 'git@github.com:pulibrary/voyager_helpers.git', :tag => 'v0.1.2'
+gem 'voyager_helpers', git: 'git@github.com:pulibrary/voyager_helpers.git', :tag => 'v0.2.0'
 
 gem 'responders', '~> 2.0'
 gem 'marc', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,10 +12,10 @@ GIT
 
 GIT
   remote: git@github.com:pulibrary/voyager_helpers.git
-  revision: 6978e87149b86e30bdf93f68d0b2a1c89be4e805
-  tag: v0.1.2
+  revision: 70ad3bb6c5eed293a33d51dcd0f212eab368fd04
+  tag: v0.2.0
   specs:
-    voyager_helpers (0.1.2)
+    voyager_helpers (0.2.0)
       activesupport (~> 4.1)
       diffy (~> 3.0.7)
       marc (~> 1.0)
@@ -162,7 +162,7 @@ GEM
       marc (~> 1.0)
     mime-types (2.99.1)
     mini_portile2 (2.0.0)
-    minitest (5.8.4)
+    minitest (5.9.0)
     mono_logger (1.1.0)
     multi_json (1.10.1)
     multipart-post (2.0.0)
@@ -367,4 +367,4 @@ DEPENDENCIES
   yaml_db (~> 0.3.0)
 
 BUNDLED WITH
-   1.11.2
+   1.12.4

--- a/app/controllers/patron_controller.rb
+++ b/app/controllers/patron_controller.rb
@@ -12,6 +12,17 @@ class PatronController < ApplicationController
     end
   end
 
+  def patron_codes
+    data = VoyagerHelpers::Liberator.get_patron_stat_codes(sanitize(params[:patron_id]))
+    if data.empty?
+      render text: {}, status: 404
+    else
+      respond_to do |wants|
+        wants.json  { render json: MultiJson.dump(data) }
+      end
+    end
+  end
+
   private
   def protect
     unless user_signed_in?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,4 +24,5 @@ Rails.application.routes.draw do
 
   get '/codes/:location', to: 'codes#locations', defaults: { format: :json }
   get '/patron/:patron_id', to: 'patron#patron_info', defaults: { format: :json }
+  get '/patron/:patron_id/codes', to: 'patron#patron_codes', defaults: { format: :json }
 end

--- a/spec/controllers/patron_controller_spec.rb
+++ b/spec/controllers/patron_controller_spec.rb
@@ -34,9 +34,21 @@ RSpec.describe PatronController, :type => :controller do
     expect(response).to have_http_status(404)
   end
 
+  it "authorized IPs can return patron stat codes" do
+    stub_patron_codes('steve')
+    allow_any_instance_of(ActionDispatch::Request).to receive(:remote_ip).and_return('192.168.0.1')
+    allow_any_instance_of(described_class).to receive(:load_ip_whitelist).and_return(['192.168.0.1'])    
+    get :patron_codes, patron_id: 'steve', format: :json
+    expect(response).to have_http_status(200)
+  end
 end
 
 def stub_patron(netid)
   f = File.expand_path("../../fixtures/patron-#{netid}.json",__FILE__)
   allow(VoyagerHelpers::Liberator).to receive(:get_patron_info).and_return(JSON.parse(File.read(f)))
+end
+
+def stub_patron_codes(netid)
+  f = File.expand_path("../../fixtures/patron-#{netid}-codes.json",__FILE__)
+  allow(VoyagerHelpers::Liberator).to receive(:get_patron_stat_codes).and_return(JSON.parse(File.read(f)))
 end

--- a/spec/fixtures/patron-steve-codes.json
+++ b/spec/fixtures/patron-steve-codes.json
@@ -1,0 +1,1 @@
+[{"stat_code":["EL"]},{"stat_code":["EM"]}]


### PR DESCRIPTION
Advances #63. "stat" codes actually allow us to see what specific borrowing groups a person belongs to. The "patron_group" value is way too broad. @mzelesky could you post an excel spreadsheet to our shared drive for the OL group that details how to interpret the various patron "stat" codes that are now returned by this route. Thanks.