### PR TITLE
Advance locations gem to 0.4.0.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ group :development, :test do
   gem 'rerun', '~> 0.10.0'
 end
 
-gem 'locations', git: 'git@github.com:pulibrary/locations.git', :tag => '0.3.0'
+gem 'locations', git: 'git@github.com:pulibrary/locations.git', :tag => '0.4.0'
 gem 'yaml_db', '~> 0.3.0'
 gem 'friendly_id', '~> 5.1.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,15 @@
 GIT
   remote: git@github.com:pulibrary/locations.git
-  revision: 27f4cf04bec63bd68ae4cb18fb27dc09a76269e5
-  tag: 0.3.0
+  revision: 9e9194c316440bf0e55ef3aac16a9efba761ea9c
+  tag: 0.4.0
   specs:
     locations (0.3.0)
       bootstrap-sass (~> 3.3)
+      carrierwave
       friendly_id (~> 5.1.0)
       jquery-tablesorter (~> 1.21)
       rails (~> 4.2)
+      rmagick
       yaml_db (~> 0.3.0)
 
 GIT
@@ -67,7 +69,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.4.0)
     arel (6.0.3)
-    autoprefixer-rails (6.3.3.1)
+    autoprefixer-rails (6.4.0.3)
       execjs
     bcrypt (3.1.10)
     bootstrap-sass (3.3.5)
@@ -95,6 +97,12 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    carrierwave (0.11.2)
+      activemodel (>= 3.2.0)
+      activesupport (>= 3.2.0)
+      json (>= 1.7)
+      mime-types (>= 1.16)
+      mimemagic (>= 0.3.0)
     celluloid (0.16.0)
       timers (~> 4.0.0)
     cliver (0.3.2)
@@ -120,7 +128,7 @@ GEM
     docile (1.1.5)
     dot-properties (0.1.3)
     erubis (2.7.0)
-    execjs (2.6.0)
+    execjs (2.7.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.10)
@@ -143,7 +151,7 @@ GEM
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    jquery-tablesorter (1.21.1)
+    jquery-tablesorter (1.22.3)
       railties (>= 3.2, < 6)
     json (1.8.3)
     library_stdnums (1.4.1)
@@ -163,6 +171,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
+    mimemagic (0.3.2)
     mini_portile2 (2.1.0)
     minitest (5.9.0)
     mono_logger (1.1.0)
@@ -240,6 +249,7 @@ GEM
       redis-namespace (~> 1.3)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
+    rmagick (2.16.0)
     rspec-core (3.0.4)
       rspec-support (~> 3.0.0)
     rspec-expectations (3.0.4)


### PR DESCRIPTION
After this is merged Orangelight's base URL for stackmap routing needs to be pointed at ```/locations/map```. Also need to point the main catalog at this new base URL. This allows us to kill the old shim that has a dependency on Primo's API. 