### PR TITLE
dedup series display field, remove non-filing indicators for within series search

### DIFF
--- a/marc_to_solr/Gemfile.lock
+++ b/marc_to_solr/Gemfile.lock
@@ -69,5 +69,8 @@ DEPENDENCIES
   stringex!
   traject (~> 2.0)
 
+RUBY VERSION
+   ruby 1.9.3p551 (jruby 1.7.25)
+
 BUNDLED WITH
-   1.12.4
+   1.13.1

--- a/marc_to_solr/spec/lib/config_spec.rb
+++ b/marc_to_solr/spec/lib/config_spec.rb
@@ -242,4 +242,20 @@ describe 'From traject_config.rb' do
       expect(linked_record['contains_display']).to match_array(["Sean 2011 #{zero_width}work 53 #{zero_width}Allegro"])
     end
   end
+
+  describe 'series 490 dedup, non-filing' do
+    let(:leader) { '1234567890' }
+    let(:s490) {{"490"=>{"ind1"=>"", "ind2"=>" ", "subfields"=>[{"a"=>"Series title"}]}}}
+    let(:s830) {{"830"=>{"ind1"=>"", "ind2"=>" ", "subfields"=>[{"a"=>"Series title."}]}}}
+    let(:s440) {{"440"=>{"ind1"=>"", "ind2"=>"4", "subfields"=>[{"a"=>"The Series"}]}}}
+    let(:record) { @indexer.map_record(MARC::Record.new_from_hash({ 'fields' => [s490, s830, s440], 'leader' => leader })) }
+
+    it '490s are not included when they are covered by another series field' do
+      expect(record['series_display']).to match_array(['Series title.', 'The Series'])
+    end
+
+    it 'matches for other works within series ignore non-filing characters' do
+      expect(record['more_in_this_series_t']).to match_array(['Series title.', 'Series'])
+    end
+  end
 end


### PR DESCRIPTION
Dedup series 490. Closes pulibrary/orangelight#622
Series starts with search takes filing indicator into account. Closes pulibrary/orangelight#730.