### PR TITLE
fixes order availability, current issue sort

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :development, :production do
   gem 'ruby-oci8', '~> 2.2.1'
 end
 
-gem 'voyager_helpers', git: 'git@github.com:pulibrary/voyager_helpers.git', tag: 'v0.3.0'
+gem 'voyager_helpers', git: 'git@github.com:pulibrary/voyager_helpers.git', tag: 'v0.3.1'
 
 gem 'responders', '~> 2.0'
 gem 'marc', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,10 +14,10 @@ GIT
 
 GIT
   remote: git@github.com:pulibrary/voyager_helpers.git
-  revision: 49bfe5b9c5a53a48c82d1bab60294194a7921e02
-  tag: v0.3.0
+  revision: e45dd9331a155b0508df55cbdfce43e7d133fe75
+  tag: v0.3.1
   specs:
-    voyager_helpers (0.3.0)
+    voyager_helpers (0.3.1)
       activesupport (~> 4.1)
       diffy (~> 3.0.7)
       marc (~> 1.0)


### PR DESCRIPTION
Updates voyager_helpers to v0.3.1 which fixes the following issues:
Sorts current issues by most recently received. Closes pulibrary/orangelight#745.
Uses mfhd to get more accurate order info in availability. Closes pulibrary/orangelight#721. Closes #159. 