### PR TITLE
Handling missing title language

### DIFF
--- a/app/models/jsonld_record.rb
+++ b/app/models/jsonld_record.rb
@@ -82,7 +82,10 @@ class JSONLDRecord
 
   def roman_title
     lang = vernacular_title.nil? ? title_language : title_language + "-Latn"
-    { "@value": roman_display_title, "@language": lang } if roman_display_title
+    if roman_display_title
+      return roman_display_title unless lang
+      return { "@value": roman_display_title, "@language": lang }
+    end
   end
 
   def roman_display_title

--- a/spec/models/jsonld_record_spec.rb
+++ b/spec/models/jsonld_record_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe JSONLDRecord, :type => :model do
   context 'without any data' do
     subject { described_class.new }
 
-    it 'maps the creator to dc:creator and the more specific role' do
+    it 'produces an empty document without errors' do
       expect { described_class.new }.to_not raise_error
       expect(described_class.new.to_h).to eq({})
     end
@@ -131,6 +131,18 @@ RSpec.describe JSONLDRecord, :type => :model do
         creator: ['Ẓufayrī, Luṭf Allāh ibn Muḥammad, 1570-1626', 'ظفيري، لطف الله بن محمد'],
         author: 'Ẓufayrī, Luṭf Allāh ibn Muḥammad, 1570-1626'
       }
+      expect(subject.to_h.symbolize_keys).to eq(json_ld)
+    end
+  end
+
+  context 'when the title language is missing' do
+    let(:solr_doc) {{
+      'title_citation_display'     => ['This is a test title']
+    }}
+    subject { described_class.new solr_doc }
+
+    it 'produces a title statement without language tag' do
+      json_ld = {title: 'This is a test title'}
       expect(subject.to_h.symbolize_keys).to eq(json_ld)
     end
   end


### PR DESCRIPTION
Avoids generating titles with null @language titles.