### PR TITLE
load traject config in initializer

### DIFF
--- a/app/controllers/bibliographic_controller.rb
+++ b/app/controllers/bibliographic_controller.rb
@@ -85,14 +85,7 @@ class BibliographicController < ApplicationController
   end
 
   def indexer
-    @indexer ||= setup_indexer
-  end
-
-  def setup_indexer
-    c = File.join(Rails.root, 'marc_to_solr', 'lib', 'traject_config.rb')
-    indexer = Traject::Indexer.new
-    indexer.load_config_file(c)
-    indexer
+    TRAJECT_INDEXER
   end
 
   def bib_holdings

--- a/config/initializers/traject_initializer.rb
+++ b/config/initializers/traject_initializer.rb
@@ -1,0 +1,9 @@
+
+def setup_indexer
+  c = File.join(Rails.root, 'marc_to_solr', 'lib', 'traject_config.rb')
+  indexer = Traject::Indexer.new
+  indexer.load_config_file(c)
+  indexer
+end
+
+TRAJECT_INDEXER ||= setup_indexer


### PR DESCRIPTION
The memoization for loading the traject config doesn't work in the controller, so I moved it to an initializer. Speeds up the load time for the /solr and /jsonld views significantly.