### PR TITLE
extend json-ld with geo-related fields

### DIFF
--- a/app/models/jsonld_record.rb
+++ b/app/models/jsonld_record.rb
@@ -117,7 +117,10 @@ class JSONLDRecord
       pub_created_display:   'publisher',
       subject_facet:         'subject',
       coverage_display:      'coverage',
-      title_sort:            'title_sort'
+      title_sort:            'title_sort',
+      alt_title_246_display: 'alternative',
+      scale_display:         'cartographic_scale',
+      projection_display:    'cartographic_projection'
     }
   end
 

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -241,6 +241,10 @@ to_field 'coverage_display' do |record, accumulator|
   accumulator[0] = coverage unless coverage.nil?
 end
 
+to_field 'scale_display', extract_marc('255a')
+
+to_field 'projection_display', extract_marc('255b:342a')
+
 # Arrangement:
 # #    351 XX 3abc
 to_field 'arrangement_display', extract_marc('351abc')
@@ -615,7 +619,7 @@ end
 
 to_field 'lc_rest_facet' do |record, accumulator|
   if record['050']
-    if record['050']['a']     
+    if record['050']['a']
       letters = /([[:alpha:]])*/.match(record['050']['a'])[0]
       accumulator << Traject::TranslationMap.new("callnumber_map")[letters]
     end
@@ -625,7 +629,7 @@ end
 to_field 'sudoc_facet' do |record, accumulator|
   MarcExtractor.cached('086|0 |a').collect_matching_lines(record) do |field, spec, extractor|
     letters = /([[:alpha:]])*/.match(extractor.collect_subfields(field, spec).first)[0] if /([[:alpha:]])*/.match(extractor.collect_subfields(field, spec).first)
-    accumulator << Traject::TranslationMap.new("sudocs")[letters] if !Traject::TranslationMap.new("sudocs")[letters].nil?    
+    accumulator << Traject::TranslationMap.new("sudocs")[letters] if !Traject::TranslationMap.new("sudocs")[letters].nil?
   end
 end
 
@@ -636,41 +640,41 @@ to_field 'call_number_scheme_facet' do |record, accumulator|
       letters = /([[:alpha:]])*/.match(record['050']['a'])[0]
       accumulator << "Library of Congress" if !Traject::TranslationMap.new("callnumber_map")[letters].nil?
     end
-  end  
+  end
   MarcExtractor.cached('086|0 |a').collect_matching_lines(record) do |field, spec, extractor|
     letters = /([[:alpha:]])*/.match(extractor.collect_subfields(field, spec).first)[0] if /([[:alpha:]])*/.match(extractor.collect_subfields(field, spec).first)
-    accumulator << "Superintendent of Documents" if !Traject::TranslationMap.new("sudocs")[letters].nil?    
+    accumulator << "Superintendent of Documents" if !Traject::TranslationMap.new("sudocs")[letters].nil?
   end
 end
 
 to_field 'call_number_group_facet' do |record, accumulator|
   MarcExtractor.cached('050a').collect_matching_lines(record) do |field, spec, extractor|
     if record['050']['a']
-      if /([[:alpha:]])*/.match(extractor.collect_subfields(field, spec).first)  
+      if /([[:alpha:]])*/.match(extractor.collect_subfields(field, spec).first)
         letters = /([[:alpha:]])*/.match(extractor.collect_subfields(field, spec).first)[0]
         first_letter = record['050']['a'].lstrip.slice(0, 1)
-        accumulator << Traject::TranslationMap.new("callnumber_map")[first_letter] if !Traject::TranslationMap.new("callnumber_map")[letters].nil?  
+        accumulator << Traject::TranslationMap.new("callnumber_map")[first_letter] if !Traject::TranslationMap.new("callnumber_map")[letters].nil?
       end
     end
-  end  
+  end
   MarcExtractor.cached('086|0 |a').collect_matching_lines(record) do |field, spec, extractor|
     letters = /([[:alpha:]])*/.match(extractor.collect_subfields(field, spec).first)[0] if /([[:alpha:]])*/.match(extractor.collect_subfields(field, spec).first)
-    accumulator << Traject::TranslationMap.new("sudocs_split")[letters] if !Traject::TranslationMap.new("sudocs_split")[letters].nil? 
+    accumulator << Traject::TranslationMap.new("sudocs_split")[letters] if !Traject::TranslationMap.new("sudocs_split")[letters].nil?
   end
 end
 
 to_field 'call_number_full_facet' do |record, accumulator|
   MarcExtractor.cached('050a').collect_matching_lines(record) do |field, spec, extractor|
     if record['050']['a']
-      if /([[:alpha:]])*/.match(extractor.collect_subfields(field, spec).first)    
-        letters = /([[:alpha:]])*/.match(extractor.collect_subfields(field, spec).first)[0] 
+      if /([[:alpha:]])*/.match(extractor.collect_subfields(field, spec).first)
+        letters = /([[:alpha:]])*/.match(extractor.collect_subfields(field, spec).first)[0]
         accumulator << Traject::TranslationMap.new("callnumber_map")[letters]
       end
     end
-  end  
+  end
   MarcExtractor.cached('086|0 |a').collect_matching_lines(record) do |field, spec, extractor|
     letters = /([[:alpha:]])*/.match(extractor.collect_subfields(field, spec).first)[0] if /([[:alpha:]])*/.match(extractor.collect_subfields(field, spec).first)
-    accumulator << Traject::TranslationMap.new("sudocs")[letters] if !Traject::TranslationMap.new("sudocs")[letters].nil?    
+    accumulator << Traject::TranslationMap.new("sudocs")[letters] if !Traject::TranslationMap.new("sudocs")[letters].nil?
   end
 end
 
@@ -766,6 +770,8 @@ to_field 'other_title_display' do |record, accumulator|
   end
   accumulator.uniq!
 end
+
+to_field 'alt_title_246_display', extract_marc('246abfnp')
 
 # 246 hash, 2nd indicator is used for label (hash key), prefer $i if present
 to_field 'other_title_1display' do |record, accumulator|

--- a/public/context.json
+++ b/public/context.json
@@ -2,6 +2,7 @@
   "@context": {
     "id" : "@id",
     "bf": "http://id.loc.gov/ontologies/bibframe/",
+    "bf1": "http://bibframe.org/vocab/",
     "dc": "http://purl.org/dc/elements/1.1/",
     "dcterms": "http://purl.org/dc/terms/",
     "edm": "http://www.europeana.eu/schemas/edm/",
@@ -14,6 +15,7 @@
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "skos": "http://www.w3.org/2004/02/skos/core#",
 
+    "alternative": {"@id": "dc:alternative"},
     "contributor": {"@id": "dc:contributor"},
     "coverage": {"@id": "dc:coverage"},
     "creator": {"@id": "dc:creator"},
@@ -35,7 +37,10 @@
     "title": {"@id": "dcterms:title"},
     "abstract": {"@id": "dcterms:abstract"},
 
+
     "edition": {"@id": "bf:editionStatement"},
+    "cartographic_projection": {"@id": "bf1:cartographicProjection"},
+    "cartographic_scale": {"@id": "bf1:cartographicScale"},
     "edm_rights": {"@id": "edm:rights"},
     "title_sort": {"@id": "mods:titleForSort"},
     "memberOf": {"@id": "pcdm:memberOf"},


### PR DESCRIPTION
Adds alternative title, scale, and projection fields to json-ld service. Advances pulibrary/plum#1160 and pulibrary/plum#1161.