### PR TITLE
Contents note

### DIFF
--- a/app/models/jsonld_record.rb
+++ b/app/models/jsonld_record.rb
@@ -121,7 +121,8 @@ class JSONLDRecord
       alt_title_246_display: 'alternative',
       scale_display:         'cartographic_scale',
       projection_display:    'cartographic_projection',
-      geocode_display:       'spatial'
+      geocode_display:       'spatial',
+      contents_display:      'contents'
     }
   end
 

--- a/marc_to_solr/lib/geo.rb
+++ b/marc_to_solr/lib/geo.rb
@@ -11,8 +11,8 @@ def decimal_coordinate record
       c['n'] = s_field.value if s_field.code == 'f' and valid_coordinate_format?(s_field.value, record)
       c['s'] = s_field.value if s_field.code == 'g' and valid_coordinate_format?(s_field.value, record)
     end
-    if c.length != 4
-      "#{record['001']} - missing coordinate"
+    if c.length != 4 and !c.empty?
+      logger.error "#{record['001']} - missing coordinate"
       break
     end
     coverage << "northlimit=#{c['n']}; eastlimit=#{c['e']}; southlimit=#{c['s']}; westlimit=#{c['w']}; units=degrees; projection=EPSG:4326"
@@ -23,7 +23,6 @@ end
 
 def valid_coordinate_format? c, record
   unless c =~ /^[-+]?[0-9]*\.?[0-9]+$/
-    logger.error "#{record['001']} - coordinate unrecognized format"
     return false
   end
   true

--- a/marc_to_solr/lib/geo.rb
+++ b/marc_to_solr/lib/geo.rb
@@ -11,7 +11,7 @@ def decimal_coordinate record
       c['n'] = s_field.value if s_field.code == 'f' and valid_coordinate_format?(s_field.value, record)
       c['s'] = s_field.value if s_field.code == 'g' and valid_coordinate_format?(s_field.value, record)
     end
-    if c.length != 4 and !c.empty?
+    if c.length != 4
       logger.error "#{record['001']} - missing coordinate"
       break
     end

--- a/public/context.json
+++ b/public/context.json
@@ -37,6 +37,7 @@
     "spatial": {"@id": "dcterms:spatial"},
     "title": {"@id": "dcterms:title"},
     "abstract": {"@id": "dcterms:abstract"},
+    "contents": {"@id": "dcterms:tableOfContents"},
 
 
     "edition": {"@id": "bf:editionStatement"},


### PR DESCRIPTION
Adds contents_display field to the json-ld service. Advances pulibrary/plum#1209.

Also turns off Traject logging for non-decimal coordinates, which clutters up the logs too much in the daily update/full reindex processes.



