### PR TITLE
pass through hold request status for recap scsb items

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :development, :production do
   gem 'ruby-oci8', '~> 2.2.1'
 end
 
-gem 'voyager_helpers', github: "pulibrary/voyager_helpers", tag: 'v0.4.7'
+gem 'voyager_helpers', github: "pulibrary/voyager_helpers", tag: 'v0.4.8'
 gem 'responders', '~> 2.0'
 gem 'marc', '~> 1.0'
 gem 'rack-conneg', '~> 0.1.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,10 +21,10 @@ GIT
 
 GIT
   remote: git://github.com/pulibrary/voyager_helpers.git
-  revision: dd7c428a8d96859ae652dfd42ce66fce663220eb
-  tag: v0.4.7
+  revision: 168638469fe9d4968822107f0e7b39f4ea657357
+  tag: v0.4.8
   specs:
-    voyager_helpers (0.4.3)
+    voyager_helpers (0.4.8)
       activesupport (~> 4.1)
       diffy (~> 3.0.7)
       marc (~> 1.0)

--- a/app/controllers/availability_controller.rb
+++ b/app/controllers/availability_controller.rb
@@ -82,6 +82,14 @@ class AvailabilityController < ApplicationController
     ['Order Received', 'Pending Order', 'On-Order']
   end
 
+  def not_charged
+    'Not Charged'
+  end
+
+  def hold_request
+    'Hold Request'
+  end
+
   def on_site
     'On-Site'
   end
@@ -96,6 +104,15 @@ class AvailabilityController < ApplicationController
 
   def inaccessible?(code)
     inaccessible_locations.include?(code)
+  end
+
+  # only recap non-aeon items retain the hold request status
+  def scsb_status(loc, status)
+    if loc.library.code == 'recap' && !loc.aeon_location
+      hold_request
+    else
+      not_charged
+    end
   end
 
   def order_status?(status)
@@ -124,6 +141,7 @@ class AvailabilityController < ApplicationController
   # always requestable non-circulating items should always have 'limited' status,
   # even with unavailable Voyager status
   def location_based_status(loc, status)
+    status = scsb_status(loc, status) if status == 'Hold Request'
     if loc.always_requestable
       always_requestable_status(status)
     elsif !loc.circulates


### PR DESCRIPTION
Closes #250.
Makes the following changes for items with a voyager status of "Hold Request":
 - Recap non-aeon items will maintain the "Hold Request" status
 - Recap aeon items will process a "Non Charged" request. Since all recap aeon items are also marked "Always Requestable," the availability status response is "On Site"
 - All non recap items will be processed as a non "Non Charged" request. These items will display as available, but may have an "On Site" label if the location is non-circulating.