### PR TITLE
remove nil elements from language code array

### DIFF
--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -557,7 +557,7 @@ end
 to_field 'script_display', extract_marc('546b')
 
 to_field 'language_code_s', extract_marc('008[35-37]:041a:041d') do |record, accumulator|
-  codes = accumulator.map { |c| c.length == 3 ? c : c.scan(/.{1,3}/) }
+  codes = accumulator.compact.map { |c| c.length == 3 ? c : c.scan(/.{1,3}/) }
   accumulator.replace(codes.flatten.uniq)
 end
 # Contents:


### PR DESCRIPTION
Allows records with 008 issues (namely being shorter than the expected fixed length) to index. Removes nil elements that correspond to a non-existent 008[35-37] code. See #264.