### PR TITLE
update rake index task to require MARC env var

### DIFF
--- a/marc_to_solr/Rakefile
+++ b/marc_to_solr/Rakefile
@@ -1,0 +1,1 @@
+import "lib/tasks/orangeindex.rake"

--- a/marc_to_solr/lib/tasks/orangeindex.rake
+++ b/marc_to_solr/lib/tasks/orangeindex.rake
@@ -11,13 +11,15 @@ conn = Faraday.new(:url => 'https://bibdata.princeton.edu') do |faraday|
   faraday.adapter  Faraday.default_adapter  # make requests with Net::HTTP
 end
 
-default_solr_url = 'http://localhost:8983/solr/blacklight-core'
+default_solr_url = 'http://localhost:8983/solr/blacklight-core-development'
 
 desc "Index MARC against SET_URL, default sample fixtures against traject config solr.url"
 task :index do
-  url_arg = ENV['SET_URL'] ? "-u #{ENV['SET_URL']}" : ''
-  fixtures = ENV['MARC'] || 'spec/fixtures/sampleconc.mrx'
-  sh "traject -c lib/traject_config.rb #{fixtures} #{url_arg}"
+  if ENV['MARC']
+    url_arg = ENV['SET_URL'] ? "-u #{ENV['SET_URL']}" : ''
+    fixtures = ENV['MARC']
+    sh "traject -c lib/traject_config.rb #{fixtures} #{url_arg}"
+  end
 end
 
 desc "Index MARC_PATH files against SET_URL (default is production)"

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -15,7 +15,7 @@ extend Traject::Macros::Marc21Semantics
 extend Traject::Macros::MarcFormats
 
 settings do
-  provide "solr.url", "http://localhost:8983/solr/blacklight-core" # default
+  provide "solr.url", "http://localhost:8983/solr/blacklight-core-development" # default
   provide "solr.version", "4.10.0"
   provide "marc_source.type", "xml"
   provide "solrj_writer.commit_on_close", "true"


### PR DESCRIPTION
This will make it less easy to accidentally index the fixtures into production solr instances by forgetting to provide the correct environment variable.