### PR TITLE
Adds subfield x as a label option for Open Access titles for 856 links.

### DIFF
--- a/marc_to_solr/lib/princeton_marc.rb
+++ b/marc_to_solr/lib/princeton_marc.rb
@@ -49,18 +49,18 @@ module MARC
 
     def date_from_008
       if self['008']
-        d = self['008'].value[7,4] 
+        d = self['008'].value[7,4]
         d = d.gsub 'u', '0' unless d == 'uuuu'
-        d = d.gsub ' ', '0' unless d == '    '  
+        d = d.gsub ' ', '0' unless d == '    '
         d if d =~ /^[0-9]{4}$/
       end
     end
 
     def end_date_from_008
       if self['008']
-        d = self['008'].value[11,4] 
+        d = self['008'].value[11,4]
         d = d.gsub 'u', '0' unless d == 'uuuu'
-        d = d.gsub ' ', '0' unless d == '    '  
+        d = d.gsub ' ', '0' unless d == '    '
         d if d =~ /^[0-9]{4}$/
       end
     end
@@ -318,7 +318,7 @@ def electronic_access_links record
       holding_id = s_field.value if s_field.code == '0'
       url = s_field.value if s_field.code == 'u'
       z_label = s_field.value if s_field.code == 'z'
-      if s_field.code == 'y' || s_field.code == '3'
+      if s_field.code == 'y' || s_field.code == '3' || s_field.code == 'x'
         if anchor_text
           anchor_text << ": #{s_field.value}"
         else
@@ -631,7 +631,7 @@ def process_recap_notes record
         end
       end
     end
-    if partner_lib == 'scsbnypl' 
+    if partner_lib == 'scsbnypl'
       partner_display_string = 'N'
     elsif partner_lib == 'scsbcul'
       partner_display_string = 'C'

--- a/marc_to_solr/spec/lib/princeton_marc_spec.rb
+++ b/marc_to_solr/spec/lib/princeton_marc_spec.rb
@@ -19,6 +19,7 @@ describe 'From princeton_marc.rb' do
       @url1 = 'google.com'
       @url2 = 'yahoo.com'
       @url3 = 'princeton.edu'
+      @url4 = 'handle.net'
       @long_url = 'http://aol.com/234/asdf/24tdsfsdjf'
       @invalid_url = 'mail.usa not link'
       @l856 = {"856"=>{"ind1"=>" ", "ind2"=>" ", "subfields"=>[{"u"=>@url1}, {"y"=>"GOOGLE!"}, {"z"=>"label"} ]}}
@@ -26,7 +27,8 @@ describe 'From princeton_marc.rb' do
       @l856_2 = {"856"=>{"ind1"=>" ", "ind2"=>" ", "subfields"=>[{"u"=>@long_url}]}}
       @l856_3 = {"856"=>{"ind1"=>" ", "ind2"=>" ", "subfields"=>[{"u"=>@url3}, {"y"=>"text 1"}, {"3"=>"text 2"}]}}
       @l856_4 = {"856"=>{"ind1"=>" ", "ind2"=>" ", "subfields"=>[{"u"=>@invalid_url}]}}
-      @sample_marc = MARC::Record.new_from_hash({ 'fields' => [@l856, @l856_1, @l856_2, @l856_3, @l856_4] })
+      @l856_5 = {"856"=>{"ind1"=>" ", "ind2"=>" ", "subfields"=>[{"u"=>@url4}, {"x"=>"Open Access"} ]}}
+      @sample_marc = MARC::Record.new_from_hash({ 'fields' => [@l856, @l856_1, @l856_2, @l856_3, @l856_4, @l856_5] })
       @links = @indexer.send(:electronic_access_links, @sample_marc)
     end
 
@@ -35,6 +37,7 @@ describe 'From princeton_marc.rb' do
       expect(@links[@url2]).to eq(["Table of contents"])
       expect(@links[@url3]).to eq(["text 1: text 2"])
       expect(@links[@long_url]).to eq(["aol.com"])
+      expect(@links[@url4]).to eq(["Open Access"])
     end
 
     it 'skips invalid urls' do


### PR DESCRIPTION
Addresses #271. The link label will literally be "Open Access" as this stands. @tampakis does that seem reasonable?