### PR TITLE
refactor index rake tasks to only commit once

### DIFF
--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -18,7 +18,6 @@ settings do
   provide "solr.url", "http://localhost:8983/solr/blacklight-core-development" # default
   provide "solr.version", "4.10.0"
   provide "marc_source.type", "xml"
-  provide "solrj_writer.commit_on_close", "true"
   provide "solr_writer.max_skipped", "50"
   provide "marc4j_reader.source_encoding", "UTF-8"
   provide "log.error_file", "/tmp/error.log"


### PR DESCRIPTION
@kevinreiss this change will have traject post a commit to solr only once per rake task call. Since the index is so large each commit takes about 2 minutes for solr to process. When running through hundreds of scsb update files this can cause the update process to take a very long time.

I cleaned up, refactored, and tested out each of the methods, but please take a close look when you get a chance.