### PR TITLE
Ensures that MARC subfield 776$i is indexed into the Solr field "related_record_info_display"

### DIFF
--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -440,6 +440,9 @@ to_field 'contained_in_s', extract_marc('773w')
 #    3500 BBID774W
 to_field 'related_record_s', extract_marc('774w')
 
+# Description for the related record
+to_field 'related_record_info_display', extract_marc('776i')
+
 # Restrictions note:
 #    506 XX 3abcde
 to_field 'restrictions_note_display', extract_marc('5063abcde')

--- a/marc_to_solr/spec/lib/config_spec.rb
+++ b/marc_to_solr/spec/lib/config_spec.rb
@@ -274,6 +274,15 @@ describe 'From traject_config.rb' do
     end
   end
 
+  describe '#related_record_info_display' do
+    let(:i776) {{"776" => {"ind1" => "", "ind2" => "", "subfields" => [{"i" => "Test description"}]}}}
+    let(:linked_record) { @indexer.map_record(MARC::Record.new_from_hash({ 'fields' => [i776], 'leader' => leader })) }
+
+    it 'indexes the 776$i value' do
+      expect(linked_record['related_record_info_display']).to include('Test description')
+    end
+  end
+
   describe 'name_uniform_title_display field' do
     let(:n100) {{"100"=>{"ind1"=>"", "ind2"=>" ", "subfields"=>[{"6"=>"880-01"}, {"a"=>"Name,"}]}}}
     let(:n100_vern) {{"880"=>{"ind1"=>"", "ind2"=>" ", "subfields"=>[{"6"=>"100-01"}, {"a"=>"AltName ;"}]}}}


### PR DESCRIPTION
Resolves #285 