### PR TITLE
Revert "Indexes the 730$p subfield into the title"

### DIFF
--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -91,8 +91,6 @@ to_field 'title_display', extract_marc('245abcfghknps', :alternate_script => fal
 
 to_field 'title_a_index', extract_marc('245a', :trim_punctuation => true)
 
-to_field 'title_p_index', extract_marc('730p', :trim_punctuation => true)
-
 to_field 'title_vern_display', extract_marc('245abcfghknps', :alternate_script => :only, :first => true)
 to_field 'cjk_title', extract_marc('245abcfghknps', :alternate_script => :only)
 

--- a/marc_to_solr/spec/lib/config_spec.rb
+++ b/marc_to_solr/spec/lib/config_spec.rb
@@ -259,15 +259,6 @@ describe 'From traject_config.rb' do
     end
   end
 
-  describe 'title_p_index' do
-    let(:p730) {{"730"=>{"ind1"=>"", "ind2"=>"", "subfields"=>[{"a"=> "Weinwirtschaft.", "p"=>"Technik."}]}}}
-
-    it 'indexes the 730$p subfield for the title' do
-      indexed = @indexer.map_record(MARC::Record.new_from_hash({ 'fields' => [p730], 'leader' => leader }))
-      expect(indexed['title_p_index']).to include('Technik')
-    end
-  end
-
   describe 'both a and t must be present in linked title field' do
     let(:t760) {{"760"=>{"ind1"=>"", "ind2"=>" ", "subfields"=>[{"t"=>"TITLE"}]}}}
     let(:a762) {{"762"=>{"ind1"=>"", "ind2"=>" ", "subfields"=>[{"a"=>"NAME"}]}}}


### PR DESCRIPTION
Reverts pulibrary/marc_liberation#295

As identified by @tampakis , this field was actually already indexed:
https://github.com/pulibrary/marc_liberation/blob/master/marc_to_solr/lib/traject_config.rb#L789
