### PR TITLE
Implements the IIIFManifestURLBuilder for constructing and caching IIIF manifest URL's

### DIFF
--- a/marc_to_solr/lib/iiif_manifest_url_builder.rb
+++ b/marc_to_solr/lib/iiif_manifest_url_builder.rb
@@ -1,0 +1,27 @@
+# Class for building instances of URI::HTTPS for IIIF Manifest URL's
+class IIIFManifestUrlBuilder
+  # Constructor
+  # @param ark_cache [CompositeCacheMap] composite of caches for mapping ARK's to repository resource ID's
+  # @param service_host [String] the host name for the repository instance
+  # @todo Resolve the service_host default parameter properly (please @see https://github.com/pulibrary/marc_liberation/issues/313)
+  def initialize(ark_cache:, service_host:)
+    @ark_cache = ark_cache
+    @service_host = service_host
+  end
+
+  # Generates an IIIF Manifest URL using an ARK
+  # @param ark [URI::ARK] the archival resource key
+  # @return URI::HTTPS the URL
+  def build(url:)
+    if url.is_a? URI::ARK
+      cached_values = @ark_cache.fetch("ark:/#{url.naan}/#{url.name}")
+      return if cached_values.nil?
+
+      id = cached_values.fetch :id
+      resource_type = cached_values.fetch :internal_resource
+      human_readable_type = resource_type.underscore
+
+      URI::HTTPS.build(host: @service_host, path: "/concern/#{human_readable_type.pluralize}/#{id}/manifest")
+    end
+  end
+end

--- a/marc_to_solr/lib/orangelight_url_builder.rb
+++ b/marc_to_solr/lib/orangelight_url_builder.rb
@@ -13,9 +13,13 @@ class OrangelightUrlBuilder
   # @param ark [URI::ARK] the archival resource key
   # @return URI::HTTPS the URL
   def build(url:)
-    cached_bib_id = @ark_cache.fetch("ark:/#{url.naan}/#{url.name}") if url.is_a? URI::ARK
-    return if cached_bib_id.nil?
+    if url.is_a? URI::ARK
+      cached_values = @ark_cache.fetch("ark:/#{url.naan}/#{url.name}")
+      return if cached_values.nil?
 
-    URI::HTTPS.build(host: @service_host, path: "/catalog/#{cached_bib_id}", fragment: 'view')
+      cached_bib_id = cached_values.fetch :source_metadata_identifier
+
+      URI::HTTPS.build(host: @service_host, path: "/catalog/#{cached_bib_id}", fragment: 'view')
+    end
   end
 end


### PR DESCRIPTION
Resolves #351 by addressing the following:
- Caches Solr Doc. IDs and repository resource types
- Implements the IIIFManifestURLBuilder for constructing IIIF URLs
- Extends handling for IIIF Manifest URL building for both Figgy and Plum