### PR TITLE
Patching for cases where internal_resource_ssim is not found in the Solr Doc.

### DIFF
--- a/marc_to_solr/lib/cache_map.rb
+++ b/marc_to_solr/lib/cache_map.rb
@@ -78,7 +78,7 @@ class CacheMap
         bib_ids = doc.fetch('source_metadata_identifier_ssim', [])
         id = doc.fetch('id')
         # Grab the human readable type
-        resource_types = doc.fetch('internal_resource_ssim')
+        resource_types = doc.fetch('internal_resource_ssim', nil) || doc.fetch('has_model_ssim', nil)
         resource_type = resource_types.first
 
         ark = arks.first


### PR DESCRIPTION
Discovered when trying to cache the search results from https://plum.princeton.edu/catalog.json?rows=1