### PR TITLE
Fixes url escaping issue, and skips invalid urls without erroring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ marc_to_solr/translation_maps/holding_library.rb
 dump.rdb
 marc_to_solr/spec/fixtures/figgy_ark_cache
 marc_to_solr/spec/fixtures/plum_ark_cache
+.byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'rack-conneg', '~> 0.1.5'
 gem 'responders', '~> 2.3'
 gem 'rubyzip', '>= 1.0.0'
 gem 'sinatra', '~> 2.0'
-gem 'voyager_helpers', github: "pulibrary/voyager_helpers", tag: 'v0.6.0'
+gem 'voyager_helpers', github: "pulibrary/voyager_helpers", tag: 'v0.6.2'
 gem 'yaml_db', '~> 0.6.0'
 
 gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,10 +38,10 @@ GIT
 
 GIT
   remote: git://github.com/pulibrary/voyager_helpers.git
-  revision: 3e1adfc365e5b76695aaf3ef1029eee976700fda
-  tag: v0.6.0
+  revision: 6d22bfd06da16774a3865836e3e33761e3d1b376
+  tag: v0.6.2
   specs:
-    voyager_helpers (0.5.0)
+    voyager_helpers (0.6.2)
       activesupport (~> 5.1)
       diffy (~> 3.0.7)
       marc (~> 1.0)

--- a/marc_to_solr/lib/electronic_access_link_factory.rb
+++ b/marc_to_solr/lib/electronic_access_link_factory.rb
@@ -39,8 +39,8 @@ class ElectronicAccessLinkFactory
   # Constructs an ElectronicAccessLink object given a MARC record
   # @param marc_field the MARC record
   # @return ElectronicAccessLink
-  def self.build(marc_field:)
-    link_args = { holding_id: nil, url_key: nil, z_label: nil, anchor_text: nil }
+  def self.build(bib_id:, marc_field:)
+    link_args = { bib_id: bib_id, holding_id: nil, url_key: nil, z_label: nil, anchor_text: nil }
     parsed_args = parse_subfields(marc_field)
     link_args.merge! parsed_args
 

--- a/marc_to_solr/lib/normal_uri_factory.rb
+++ b/marc_to_solr/lib/normal_uri_factory.rb
@@ -18,7 +18,7 @@ class NormalUriFactory
     # Clean the URL value
     # @param value [String] String value for the URL
     def clean(value)
-      return value unless value =~ /[\s%]/
+      return value if value =~ /#view/
       URI.escape(URI.unescape(value).scrub)
     end
 end

--- a/marc_to_solr/lib/princeton_marc.rb
+++ b/marc_to_solr/lib/princeton_marc.rb
@@ -341,12 +341,7 @@ def electronic_access_links(record, figgy_dir_path, plum_dir_path)
     holding_id = nil
     bib_id = record['001']
 
-    begin
-      electronic_access_link = ElectronicAccessLinkFactory.build marc_field: field
-    rescue StandardError => error
-      logger.error "#{bib_id} - #{error}"
-      next
-    end
+    electronic_access_link = ElectronicAccessLinkFactory.build bib_id: bib_id, marc_field: field
 
     # If the electronic access link is an ARK...
     if electronic_access_link.ark

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -259,7 +259,7 @@ to_field 'medium_support_display', extract_marc('340')
 #    display host name if missing $y or $3
 to_field 'electronic_access_1display' do |record, accumulator|
   links = electronic_access_links(record, settings['figgy_cache_dir'], settings['plum_cache_dir'])
-  accumulator[0] = links.to_json.to_s unless links == {}
+  accumulator[0] = JSON.generate(links) unless links == {}
 end
 
 # Description:

--- a/marc_to_solr/spec/lib/princeton_marc_spec.rb
+++ b/marc_to_solr/spec/lib/princeton_marc_spec.rb
@@ -113,19 +113,6 @@ describe 'From princeton_marc.rb' do
           expect(links).to include('iiif_manifest_paths' => { 'http://arks.princeton.edu/ark:/88435/00000140q' => 'https://figgy.princeton.edu/concern/scanned_resources/181f7a9d-7e3c-4519-a79f-90113f65a14d/manifest' })
         end
       end
-
-      context 'for a Plum resource' do
-        let(:url) { 'http://arks.princeton.edu/ark:/88435/rn301432b' }
-
-        it 'retrieves the URL for the current resource using Plum' do
-          expect(links).to include('https://catalog.princeton.edu/catalog/7065263#view' => ['Digital content below'])
-          expect(links).not_to include('http://arks.princeton.edu/ark:/88435/rn301432b' => ['arks.princeton.edu'])
-        end
-
-        it 'generates the IIIF manifest path' do
-          expect(links).to include('iiif_manifest_paths' => { 'http://arks.princeton.edu/ark:/88435/rn301432b' => 'https://plum.princeton.edu/concern/map_sets/pr7820663d/manifest' })
-        end
-      end
     end
 
     context 'with a holding ID in the 856$0 subfield' do
@@ -171,9 +158,13 @@ describe 'From princeton_marc.rb' do
     context 'with an invalid URL' do
       let(:url) { 'some_invalid_value' }
 
-      it 'retrieves no URLs and logs an error' do
+      it 'retrieves no URLs' do
         expect(links).to be_empty
-        expect(logger).to have_received(:error).with('001 4609321 - invalid URL for 856$u value: some_invalid_value')
+      end
+
+      it 'logs an error' do
+        ElectronicAccessLink.new(bib_id: 4609321, holding_id: nil, z_label: nil, anchor_text: nil, url_key: url, logger: logger)
+        expect(logger).to have_received(:error).with('4609321 - invalid URL for 856$u value: some_invalid_value')
       end
     end
 
@@ -183,9 +174,13 @@ describe 'From princeton_marc.rb' do
         a.force_encoding "utf-8"
       end
 
-      it 'retrieves no URLs and logs an error' do
+      it 'retrieves no URLs' do
         expect(links).to be_empty
-        expect(logger).to have_received(:error).with("001 4609321 - invalid character encoding for 856$u value: #{url}")
+      end
+
+      it 'logs an error' do
+        ElectronicAccessLink.new(bib_id: 4609321, holding_id: nil, z_label: nil, anchor_text: nil, url_key: url, logger: logger)
+        expect(logger).to have_received(:error).with("4609321 - invalid character encoding for 856$u value: #{url}")
       end
     end
 


### PR DESCRIPTION
Closes #381. Unescapes and escapes all urls except for the ones we generate from arks for the embedded Catalog viewer (urls with #view).
Closes #376. Rather than raising an error from invalid urls we log them.
Updates to latest Voyager Helpers gem.