### PR TITLE
only parse princeton arks during indexing

### DIFF
--- a/marc_to_solr/lib/cache_map.rb
+++ b/marc_to_solr/lib/cache_map.rb
@@ -58,7 +58,7 @@ class CacheMap
     value = @cache.fetch(self.class.cache_key_for(ark: ark))
 
     if value.nil?
-      @logger.warn "Failed to resolve #{ark}" if URI::ARK.ark?(url: ark)
+      @logger.warn "Failed to resolve #{ark}" if URI::ARK.princeton_ark?(url: ark)
     else
       @logger.debug "Resolved #{ark} for #{value}"
     end

--- a/marc_to_solr/lib/electronic_access_link.rb
+++ b/marc_to_solr/lib/electronic_access_link.rb
@@ -54,7 +54,7 @@ class ElectronicAccessLink
   # @return [URI::ARK]
   def ark
     # If the URL is a valid ARK...
-    return unless ark_class.ark? url: url
+    return unless ark_class.princeton_ark? url: url
 
     # Cast the URL into an ARK
     @ark ||= ark_class.parse url: url

--- a/marc_to_solr/lib/uri_ark.rb
+++ b/marc_to_solr/lib/uri_ark.rb
@@ -24,8 +24,8 @@ class URI::ARK < URI::Generic
   # Validates whether or not a URL is an ARK URL
   # @param uri [URI::Generic] a URL
   # @return [TrueClass, FalseClass]
-  def self.ark?(url:)
-    m = /ark\:\/(.+)\/(.+)\/?/.match(url.to_s)
+  def self.princeton_ark?(url:)
+    m = /[\/?]ark\:\/88435\/(.+)\/?/.match(url.to_s)
     !!m
   end
 
@@ -38,7 +38,7 @@ class URI::ARK < URI::Generic
   private
     # Extract the components from the ARK URL into member variables
     def extract_components!
-      raise StandardError, "Invalid ARK URL using: #{self.to_s}" unless self.class.ark?(url: self)
+      raise StandardError, "Invalid ARK URL using: #{self.to_s}" unless self.class.princeton_ark?(url: self)
       m = /\:\/\/(.+)\/ark\:\/(.+)\/(.+)\/?/.match(self.to_s)
 
       @nmah = m[1]

--- a/marc_to_solr/spec/lib/uri_ark_spec.rb
+++ b/marc_to_solr/spec/lib/uri_ark_spec.rb
@@ -1,0 +1,14 @@
+require_relative '../../lib/uri_ark'
+
+RSpec.describe URI::ARK do
+  describe '#princeton_ark?' do
+    let(:princeton_ark) { 'http://arks.princeton.edu/ark:/88435/9k41zd556' }
+    let(:non_princeton_ark) {  'https://nls.ldls.org.uk/welcome.html?ark:/81055/vdc_100052020059.0x000001' }
+    it 'Princeton arks return true' do
+      expect(described_class.princeton_ark?(url: princeton_ark)).to eq true
+    end
+    it 'Non-Princeton arks return false' do
+      expect(described_class.princeton_ark?(url: non_princeton_ark)).to eq false
+    end
+  end
+end


### PR DESCRIPTION
Closes #386. @jrgriffiniii can you confirm if this approach is ok? My understanding is that `ark?` method only is useful in the context of caching Princeton arks from Figgy.