### PR TITLE
Use `Addressable::URI.escape` in order to handle more problematic URLs

### DIFF
--- a/marc_to_solr/lib/electronic_access_link.rb
+++ b/marc_to_solr/lib/electronic_access_link.rb
@@ -48,6 +48,11 @@ class ElectronicAccessLink
         @url = URI.parse(@url_key)
       end
     end
+  rescue URI::InvalidURIError
+    # This handles cases where the statement @url_key !~ URI.regexp is true but this exception is still raised
+    # An example valid URL for this would be http://www.strategicstudiesinstitute.army.mil/pdffiles/PUB949[1].pdf
+    cleaned = Addressable::URI.parse(@url_key).normalize.to_s
+    @url = URI.parse(cleaned)
   end
 
   # Generates the ARK from the string URL key

--- a/marc_to_solr/spec/lib/princeton_marc_spec.rb
+++ b/marc_to_solr/spec/lib/princeton_marc_spec.rb
@@ -166,6 +166,14 @@ describe 'From princeton_marc.rb' do
       end
     end
 
+    context 'with an valid URL which incorrectly raises an exception' do
+      let(:url) { 'http://www.strategicstudiesinstitute.army.mil/pdffiles/PUB949[1].pdf' }
+
+      it 'retrieves the URLs and the link labels' do
+        expect(links).to include(url => ['www.strategicstudiesinstitute.army.mil'])
+      end
+    end
+
     context 'with an unparsable URL' do
       let(:url) do
         a = "\xFF"


### PR DESCRIPTION
The URL's aren't actually problematic, it's the manner by which `URI` handles these values differently between matching and the `.parse` method:
```
irb(main):001:0> require 'uri'
=> true
irb(main):002:0> u = 'http://www.strategicstudiesinstitute.army.mil/pdffiles/PUB949[1].pdf'
=> "http://www.strategicstudiesinstitute.army.mil/pdffiles/PUB949[1].pdf"
irb(main):003:0> URI.parse(u)
URI::InvalidURIError: bad URI(is not URI?): http://www.strategicstudiesinstitute.army.mil/pdffiles/PUB949[1].pdf
    from /usr/lib/ruby/2.4.0/uri/rfc3986_parser.rb:67:in `split'
    from /usr/lib/ruby/2.4.0/uri/rfc3986_parser.rb:73:in `parse'
    from /usr/lib/ruby/2.4.0/uri/common.rb:231:in `parse'
    from (irb):3
    from /usr/bin/irb:11:in `<main>'
irb(main):004:0> u =~ URI.regexp
=> 0
```