### PR TITLE
allow full dump events to run even when event id is nil

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -36,7 +36,7 @@ class Event < ActiveRecord::Base
       delete_ids << Dump
         .where(dump_type: DumpType.find_by(constant: 'BIB_IDS'))
         .order("id DESC").offset(8).pluck(:event_id)
-      delete_ids.flatten!
+      delete_ids.flatten!.compact!
       Event.destroy(delete_ids)
     end
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -18,10 +18,16 @@ RSpec.describe Event, type: :model do
   end
 
   describe 'ALL_RECORDS dump' do
-    it 'removes stale dump events after completing dump' do
+    it 'removes stale dump events after completing dump, no errors when id is nil' do
+      # Dumps without event ids would cause full dumps to fail
+      # An event id is still required to delete events
+      # (hence there being 9 holding id dump events instead of 8)
+      dump = Dump.where(dump_type: DumpType.find_by(constant: 'HOLDING_IDS')).first
+      dump.event_id = nil
+      dump.save
       Dump.full_bib_dump
       expect(dump_count('BIB_IDS')).to eq 8
-      expect(dump_count('HOLDING_IDS')).to eq 8
+      expect(dump_count('HOLDING_IDS')).to eq 9
       expect(dump_count('CHANGED_RECORDS')).to eq 8
       expect(dump_count('ALL_RECORDS')).to eq 3
     end


### PR DESCRIPTION
Fixes errors like the one below which prevent full Voyager dumps from running successfully:
<img width="1155" alt="event id nil" src="https://user-images.githubusercontent.com/4650153/39205123-d14edbf6-47c7-11e8-8c61-d5509a33ac30.png">
