### PR TITLE
allow rake task to index

### DIFF
--- a/marc_to_solr/lib/cache_manager.rb
+++ b/marc_to_solr/lib/cache_manager.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/module'
+
 # Class for handling instances of caching objects
 class CacheManager
   # Build and set the current cache to the new instance


### PR DESCRIPTION
the `delegate` method isn't loaded when called from a rake task