### PR TITLE
reject invalid language codes from iana language field

### DIFF
--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -605,7 +605,14 @@ end
 
 to_field 'language_iana_s', extract_marc('008[35-37]:041a:041d') do |_record, accumulator|
   codes = accumulator.compact.map { |c| c.length == 3 ? c : c.scan(/.{1,3}/) }.flatten.uniq
-  codes.length == 1 ? accumulator.replace(ISO_639.find(codes.join).alpha2.split) : accumulator.replace(codes.map {|e| ISO_639.find(e).alpha2.split.join(",")})
+  codes = codes.reject { |c| ISO_639.find(c).nil? }.map do |c|
+    if ISO_639.find(c).alpha2.empty?
+      c
+    else
+      ISO_639.find(c).alpha2
+    end
+  end
+  accumulator.replace(codes)
 end
 
 # Contents:

--- a/marc_to_solr/spec/fixtures/sample1.mrx
+++ b/marc_to_solr/spec/fixtures/sample1.mrx
@@ -18,6 +18,9 @@
       <marc:subfield code="a">NjP</marc:subfield>
       <marc:subfield code="c">NjP</marc:subfield>
     </marc:datafield>
+    <marc:datafield tag="041" ind1=" " ind2=" ">
+      <marc:subfield code="a">|||</marc:subfield>
+    </marc:datafield>
     <marc:datafield tag="100" ind1="1" ind2=" ">
       <marc:subfield code="a">Singh, Digvijai,</marc:subfield>
       <marc:subfield code="d">1934-</marc:subfield>

--- a/marc_to_solr/spec/lib/config_spec.rb
+++ b/marc_to_solr/spec/lib/config_spec.rb
@@ -38,12 +38,13 @@ describe 'From traject_config.rb' do
 	end
 
   describe 'the language_iana_s field' do
-    it 'returns a language value based on the IANA Language Subtag Registry' do
-      expect(@sample1['language_iana_s']).to eq(["en"])
+    it 'returns a language value based on the IANA Language Subtag Registry, rejecting invalid codes' do
+      expect(@sample1['language_code_s']).to eq(['eng', '|||'])
+      expect(@sample1['language_iana_s']).to eq(['en'])
     end
 
     it 'returns 2 language values based on the IANA Language Subtag Registry' do
-      expect(@added_title_246['language_iana_s']).to eq(["ja", "en"])
+      expect(@added_title_246['language_iana_s']).to eq(['ja', 'en'])
     end
   end
 


### PR DESCRIPTION
Closes #411. Also keeps the three-character code as a fallback when language code doesn't have a 2-character version (as per http://accessibility.psu.edu/foreignlanguages/langtaghtml/#iso639)