### PR TITLE
trim punctuation for more in this series links

### DIFF
--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -440,7 +440,7 @@ to_field 'more_in_this_series_t' do |record, accumulator|
     end
   end
   accumulator << everything_through_t(record, '800:810:811')
-  accumulator.flatten!
+  accumulator.flatten!.map! { |f| Traject::Macros::Marc21.trim_punctuation(f) }
 end
 
 

--- a/marc_to_solr/spec/lib/config_spec.rb
+++ b/marc_to_solr/spec/lib/config_spec.rb
@@ -427,8 +427,8 @@ describe 'From traject_config.rb' do
       expect(record['series_display']).to match_array(['Series title.', 'The Series'])
     end
 
-    it 'matches for other works within series ignore non-filing characters' do
-      expect(record['more_in_this_series_t']).to match_array(['Series title.', 'Series'])
+    it 'matches for other works within series ignore non-filing characters, trim punctuation' do
+      expect(record['more_in_this_series_t']).to match_array(['Series title', 'Series'])
     end
   end
   describe 'senior thesis 502 note' do


### PR DESCRIPTION
Closes pulibrary/orangelight#1323. Removes trailing punctuation to fix more in this series links.