### PR TITLE
Ensures that form/genre subfields are indexed with semicolons as delimiters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ marc_to_solr/translation_maps/holding_library.rb
 .DS_Store
 dump.rdb
 marc_to_solr/spec/fixtures/figgy_ark_cache
+marc_to_solr/spec/fixtures/plum_ark_cache
 .byebug_history

--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -823,7 +823,14 @@ end
 
 # Form/Genre
 #    655 |7 a{v--%}{x--%}{y--%}{z--%} S avxyz
-to_field 'form_genre_display', extract_marc('655avxyz')
+#to_field 'form_genre_display', extract_marc('655avxyz')
+to_field 'form_genre_display' do |record, accumulator|
+  MarcExtractor.cached('655avxyz', separator: '; ').collect_matching_lines(record) do |field, spec, extractor|
+    values = extractor.collect_subfields(field, spec)
+    value = values.join('; ')
+    accumulator << value
+  end
+end
 
 # 600/610/650/651 $v, $x filtered
 # 655 $a, $v, $x filtered

--- a/marc_to_solr/spec/fixtures/plum_ark_cache/ark__88435_rn301432b
+++ b/marc_to_solr/spec/fixtures/plum_ark_cache/ark__88435_rn301432b
@@ -1,1 +1,0 @@
-{:idI"pr7820663d:ET:source_metadata_identifierI"7065263;T:internal_resourceI"MapSet;T

--- a/marc_to_solr/spec/lib/princeton_marc_spec.rb
+++ b/marc_to_solr/spec/lib/princeton_marc_spec.rb
@@ -429,6 +429,67 @@ describe 'From princeton_marc.rb' do
     end
   end
 
+  describe 'form_genre_display' do
+    subject(:form_genre_display) { indexer.map_record(marc_record) }
+
+    let(:leader) { '1234567890' }
+    let(:field_655) do
+      {
+        "655" => {
+          "ind1" => "",
+          "ind2" => "0",
+          "subfields" => [
+            {
+              "a" => "Culture."
+            },
+            {
+              "v" => "Awesome"
+            },
+            {
+              "x" => "Dramatic rendition"
+            },
+            {
+              "y" => "19th century."
+            }
+          ]
+        }
+      }
+    end
+    let(:field_655_2) do
+      {
+        "655" => {
+          "ind1" => "",
+          "ind2" => "7",
+          "subfields" => [
+            {
+              "a" => "Poetry"
+            },
+            {
+              "x" => "Translations into French"
+            },
+            {
+              "v" => "Maps"
+            },
+            {
+              "y" => "19th century."
+            }
+          ]
+        }
+      }
+    end
+    let(:marc_record) do
+      MARC::Record.new_from_hash('leader' => leader, 'fields' => [field_655, field_655_2])
+    end
+
+    it "indexes the subfields as semicolon-delimited values" do
+      expect(form_genre_display).not_to be_empty
+      expect(form_genre_display).to include "form_genre_display"
+      expect(form_genre_display["form_genre_display"].length).to eq(2)
+      expect(form_genre_display["form_genre_display"].first).to eq("Culture.; Awesome; Dramatic rendition; 19th century.")
+      expect(form_genre_display["form_genre_display"].last).to eq("Poetry; Translations into French; Maps; 19th century.")
+    end
+  end
+
   describe 'process_genre_facet function' do
     before(:all) do
       @g600 = { "600"=>{ "ind1"=>"", "ind2"=>"0", "subfields"=>[{ "a"=>"Exclude" }, { "v"=>"John" }, { "x"=>"Join" }] } }


### PR DESCRIPTION
Resolves #460 