### PR TITLE
Update the spec to match record edits

### DIFF
--- a/spec/requests/bib_gets_spec.rb
+++ b/spec/requests/bib_gets_spec.rb
@@ -178,14 +178,14 @@ RSpec.describe "Bibliographic Gets", type: :request do
       it 'exposes the ARK' do
         bib_id = '4609321'
         stub_voyager('4609321')
-        stub_ezid(shoulder: "88435", blade: "xp68kg247")
         stub_ezid(shoulder: "88435", blade: "7d278t10z")
+        stub_ezid(shoulder: "88435", blade: "xp68kg247")
         get "/bibliographic/#{bib_id}/jsonld"
         expect(response.status).to be(200)
 
         solr_doc = JSON.parse(response.body)
         expect(solr_doc['@id']).to eq('http://www.example.com/bibliographic/4609321')
-        expect(solr_doc['identifier']).to eq 'http://arks.princeton.edu/ark:/88435/7d278t10z'
+        expect(solr_doc['identifier']).to eq 'http://arks.princeton.edu/ark:/88435/xp68kg247'
       end
     end
   end


### PR DESCRIPTION
The record was changed because the wrong ark was coming through.