### PR TITLE
Override default spec task to set env vars and run all tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,3 +39,8 @@ Naming/AccessorMethodName:
   Exclude:
     - 'app/models/concerns/scsb_partner_updates.rb'
     - 'marc_to_solr/lib/princeton_marc.rb'
+
+Lint/HandleExceptions:
+  Exclude:
+    - 'lib/tasks/spec.rake'
+    - 'marc_to_solr/lib/location_extract.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -410,11 +410,6 @@ Lint/EnsureReturn:
     - 'app/models/event.rb'
 
 # Offense count: 1
-Lint/HandleExceptions:
-  Exclude:
-    - 'marc_to_solr/lib/location_extract.rb'
-
-# Offense count: 1
 Lint/ParenthesesAsGroupedExpression:
   Exclude:
     - 'app/models/jsonld_record.rb'

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Ensure redis is running
 To run the tests in the `marc_to_solr` directory set RAILS_ENV:
 `$ RAILS_ENV=test bundle exec rspec marc_to_solr/spec`
 
+To run all the tests use the rake task, which sets some environment variables for you:
+`$ rake spec`
+
 ## License
 
 See `LICENSE`.

--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,3 @@ RuboCop::RakeTask.new do |task|
   task.requires << 'rubocop-rspec'
   task.fail_on_error = true
 end
-
-desc 'Run test suite and style checker'
-task spec: :rubocop

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -1,0 +1,10 @@
+task("spec").clear
+desc "Run rspec with required env variables"
+task :spec do
+  if Rails.env.development? || Rails.env.staging?
+    ENV['FIGGY_ARK_CACHE_PATH'] = 'marc_to_solr/spec/fixtures/figgy_ark_cache'
+    ENV['TRAJECT_CONFIG'] = 'marc_to_solr/lib/traject_config.rb'
+    ENV['BIBDATA_ADMIN_NETIDS'] = 'admin123'
+    sh "rspec spec marc_to_solr/spec"
+  end
+end


### PR DESCRIPTION
Also removes rubocop from the spec task; with new circle ci that is a
separate ci step and people can run it individually as needed