### PR TITLE
Scsb index tasks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,9 @@ Rails:
 Rails/Date:
   Enabled: false
 
+Rails/TimeZone:
+  Enabled: false
+
 AllCops:
   DisplayCopNames: true
   TargetRubyVersion: 2.3

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -632,16 +632,6 @@ Rails/RequestReferer:
     - 'app/controllers/application_controller.rb'
 
 # Offense count: 1
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: strict, flexible
-Rails/TimeZone:
-  Exclude:
-    - 'app/models/dump.rb'
-    - 'app/models/concerns/scsb_partner_updates.rb'
-    - 'spec/models/concerns/scsb_partner_updates_spec.rb'
-    - 'spec/models/dump_spec.rb'
-
-# Offense count: 1
 # Cop supports --auto-correct.
 Security/YAMLLoad:
   Exclude:

--- a/app/models/concerns/scsb_partner_updates.rb
+++ b/app/models/concerns/scsb_partner_updates.rb
@@ -99,6 +99,7 @@ module Scsb
           end
           File.unlink(file)
         end
+        filepaths = []
         Dir.glob("#{@update_directory}/*.xml").each do |file|
           filename = File.basename(file)
           reader = MARC::XMLReader.new(file.to_s, external_encoding: 'UTF-8')
@@ -106,9 +107,10 @@ module Scsb
           writer = MARC::XMLWriter.new(filepath)
           reader.each { |record| writer.write(process_record(record)) }
           writer.close
-          attach_dump_file(filepath)
+          filepaths << filepath
           File.unlink(file)
         end
+        filepaths.sort.each { |f| attach_dump_file(f) }
       end
 
       def process_record(record)

--- a/app/models/dump_file.rb
+++ b/app/models/dump_file.rb
@@ -30,6 +30,10 @@ class DumpFile < ActiveRecord::Base
     File.delete(self.path) if File.exist?(self.path)
   end
 
+  def recap_record_type?
+    self.dump_file_type == DumpFileType.find_by(constant: 'RECAP_RECORDS')
+  end
+
   def zipped?
     self.path.ends_with?('.gz')
   end

--- a/app/models/dump_file.rb
+++ b/app/models/dump_file.rb
@@ -59,7 +59,7 @@ class DumpFile < ActiveRecord::Base
       gz_path = self.path
 
       Zlib::GzipReader.open(gz_path) do |gz|
-        File.open(uncompressed_path, 'w') do |fp|
+        File.open(uncompressed_path, 'wb') do |fp|
           while chunk = gz.read(16 * 1024) do
             fp.write chunk
           end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -63,9 +63,9 @@ every 1.day, at: ["12:40am", "10:55am", "2:55pm"], roles: [:cron_production] do
 end
 
 # 3 updates to catalog-rebuild per day
-# These are 1 hour earlier than production to stagger the load on solr but ensure that
+# These are earlier than production to stagger the load on solr but ensure that
 #   no updates get lost when indices are swapped
-every 1.day, at: ["1:40am", "11:55am", "3:55pm"], roles: [:cron_production] do
+every 1.day, at: ["12:00am", "10:30am", "2:30pm"], roles: [:cron_production] do
   liberate_latest_production(
     "liberate:latest",
     set_url: ENV["SOLR_REINDEX_URL"],

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -65,7 +65,7 @@ end
 # 3 updates to catalog-rebuild per day
 # These are 1 hour earlier than production to stagger the load on solr but ensure that
 #   no updates get lost when indices are swapped
-every 1.day, at: ["11:40pm", "9:55am", "1:55pm"], roles: [:cron_production] do
+every 1.day, at: ["1:40am", "11:55am", "3:55pm"], roles: [:cron_production] do
   liberate_latest_production(
     "liberate:latest",
     set_url: ENV["SOLR_REINDEX_URL"],
@@ -77,6 +77,15 @@ end
 # Daily racap / partner jobs
 every 1.day, at: "3:00pm", roles: [:cron_production] do
   rake "marc_liberation:recap_dump", output: "/tmp/cron_log.log"
+end
+
+every 1.day, at: "6:30am", roles: [:cron_production] do
+  liberate_latest_production(
+    "scsb:latest",
+    set_url: ENV["SOLR_URL"],
+    update_locations: "true",
+    output: "/tmp/daily_updates.log"
+  )
 end
 every 1.day, at: "6:00am", roles: [:cron_production] do
   rake "marc_liberation:partner_update", output: "/tmp/cron_log.log"

--- a/lib/tasks/scsb.rake
+++ b/lib/tasks/scsb.rake
@@ -1,3 +1,5 @@
+require './marc_to_solr/lib/index_functions'
+
 namespace :scsb do
   desc 'starts monitoring jobs for loops'
   task :start_daemon do
@@ -7,6 +9,48 @@ namespace :scsb do
   desc 'stops loops'
   task :stop_daemon do
     %x[bundle exec loops stop 2>&1]
+  end
+
+  desc "Index SCSB records with all changed records since SET_DATE, against SET_URL"
+  task updates: :environment do
+    if ENV['SET_URL'] && ENV['SET_DATE']
+      solr_url = ENV['SET_URL']
+      comp_time = Time.parse(ENV['SET_DATE'])
+      solr = IndexFunctions.rsolr_connection(solr_url)
+      dump_type = DumpType.find_by(constant: 'PARTNER_RECAP')
+      dump_file_type = DumpFileType.find_by(constant: 'RECAP_RECORDS')
+      dumps = Dump.where(dump_type: dump_type, created_at: comp_time..Time.now)
+      dumps.each do |dump|
+        dump.dump_files.each do |df|
+          next unless df.dump_file_type == dump_file_type
+          df.unzip
+          sh "traject -c marc_to_solr/lib/traject_config.rb #{df.path} -u #{solr_url}; true"
+          df.zip
+        end
+        solr.delete_by_id(dump.delete_ids) if dump.delete_ids
+      end
+      solr.commit
+    end
+  end
+
+  desc "Index SCSB records with most recent update, against SET_URL"
+  task latest: :environment do
+    if ENV['SET_URL']
+      solr_url = ENV['SET_URL']
+      solr = IndexFunctions.rsolr_connection(solr_url)
+      dump_type = DumpType.find_by(constant: 'PARTNER_RECAP')
+      dump_file_type = DumpFileType.find_by(constant: 'RECAP_RECORDS')
+      dumps = Dump.where(dump_type: dump_type)
+      dump = dumps.last
+      dump.dump_files.each do |df|
+        next unless df.dump_file_type == dump_file_type
+        df.unzip
+        sh "traject -c marc_to_solr/lib/traject_config.rb #{df.path} -u #{solr_url}; true"
+        df.zip
+      end
+      solr.delete_by_id(dump.delete_ids) if dump.delete_ids
+      solr.commit
+    end
   end
 
 end

--- a/lib/tasks/scsb.rake
+++ b/lib/tasks/scsb.rake
@@ -14,42 +14,18 @@ namespace :scsb do
   desc "Index SCSB records with all changed records since SET_DATE, against SET_URL"
   task updates: :environment do
     if ENV['SET_URL'] && ENV['SET_DATE']
-      solr_url = ENV['SET_URL']
       comp_time = Time.parse(ENV['SET_DATE'])
-      solr = IndexFunctions.rsolr_connection(solr_url)
-      dump_type = DumpType.find_by(constant: 'PARTNER_RECAP')
-      dump_file_type = DumpFileType.find_by(constant: 'RECAP_RECORDS')
-      dumps = Dump.where(dump_type: dump_type, created_at: comp_time..Time.now)
-      dumps.each do |dump|
-        dump.dump_files.each do |df|
-          next unless df.dump_file_type == dump_file_type
-          df.unzip
-          sh "traject -c marc_to_solr/lib/traject_config.rb #{df.path} -u #{solr_url}; true"
-          df.zip
-        end
-        solr.delete_by_id(dump.delete_ids) if dump.delete_ids
-      end
-      solr.commit
+      dumps = Dump.where(dump_type: DumpType.find_by(constant: 'PARTNER_RECAP'),
+                         created_at: comp_time..Time.now)
+      IndexFunctions.process_scsb_dumps(dumps, ENV['SET_URL'])
     end
   end
 
   desc "Index SCSB records with most recent update, against SET_URL"
   task latest: :environment do
     if ENV['SET_URL']
-      solr_url = ENV['SET_URL']
-      solr = IndexFunctions.rsolr_connection(solr_url)
-      dump_type = DumpType.find_by(constant: 'PARTNER_RECAP')
-      dump_file_type = DumpFileType.find_by(constant: 'RECAP_RECORDS')
-      dumps = Dump.where(dump_type: dump_type)
-      dump = dumps.last
-      dump.dump_files.each do |df|
-        next unless df.dump_file_type == dump_file_type
-        df.unzip
-        sh "traject -c marc_to_solr/lib/traject_config.rb #{df.path} -u #{solr_url}; true"
-        df.zip
-      end
-      solr.delete_by_id(dump.delete_ids) if dump.delete_ids
-      solr.commit
+      dumps = Dump.where(dump_type: DumpType.find_by(constant: 'PARTNER_RECAP'))
+      IndexFunctions.process_scsb_dumps([dumps.last], ENV['SET_URL'])
     end
   end
 

--- a/marc_to_solr/spec/lib/index_functions_spec.rb
+++ b/marc_to_solr/spec/lib/index_functions_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../lib/index_functions'
+
+RSpec.describe IndexFunctions do
+  describe '#delete_ids' do
+    let(:dump) do
+      { 'ids' =>
+        { 'delete_ids' => ['134', '234'] } }
+    end
+    it 'reuturns an array of bib ids for deletion' do
+      expect(described_class.delete_ids(dump)).to eq ['134', '234']
+    end
+  end
+  describe '#rsolr_connection' do
+    let(:solr) { described_class.rsolr_connection('http://example.com') }
+    it 'responds to .commit' do
+      expect(solr).to respond_to(:commit)
+    end
+    it 'responds to .delete_by_id' do
+      expect(solr).to respond_to(:delete_by_id).with(1).argument
+    end
+  end
+end

--- a/spec/models/dump_file_spec.rb
+++ b/spec/models/dump_file_spec.rb
@@ -27,6 +27,19 @@ RSpec.describe DumpFile, type: :model do
     end
   end
 
+  describe '#recap_record_type?' do
+    let(:recap_record_type) { DumpFileType.find_by(constant: 'RECAP_RECORDS') }
+    let(:other_type) { DumpFileType.create }
+    it 'returns true for RECAP_RECORDS type' do
+      df = DumpFile.new(dump_file_type: recap_record_type)
+      expect(df.recap_record_type?).to eq true
+    end
+    it 'otherwise returns false' do
+      df = DumpFile.new(dump_file_type: other_type)
+      expect(df.recap_record_type?).to eq false
+    end
+  end
+
   describe '#zip' do
     it 'changes the file path to include gz' do
       path = subject.path


### PR DESCRIPTION
Closes #244.
 - Ensures that scsb partner updates are in chronological order
 - Makes rake tasks to either index the most recent recap partner job or all since a certain date
 - Schedules job using whenever