### PR TITLE
Ensures that the latest voyager_helpers commit to the master branch is used

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'stringex', github: "pulibrary/stringex", tag: 'vpton.2.5.2.2'
 gem 'traject', '2.3.1'
 gem 'turbolinks'
 gem 'uglifier', '>= 1.3.0'
-gem 'voyager_helpers', github: "pulibrary/voyager_helpers", tag: 'v0.7.1'
+gem 'voyager_helpers', github: "pulibrary/voyager_helpers", branch: 'master'
 gem 'whenever', "~> 0.10"
 gem 'yaml_db', '~> 0.6.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,8 +46,8 @@ GIT
 
 GIT
   remote: git://github.com/pulibrary/voyager_helpers.git
-  revision: d1465caf9416c0d94c16005b378092ccef403114
-  tag: v0.7.1
+  revision: 7238ce24b5434ffca59a2dcb75a7a71e3ff3174c
+  branch: master
   specs:
     voyager_helpers (0.7.1)
       activesupport (~> 5.1)


### PR DESCRIPTION
Resolves #515 after https://github.com/pulibrary/voyager_helpers/pull/98 was merged.  Further, as `voyager_helpers` only has one dependent, (please see https://github.com/pulibrary/voyager_helpers/network/dependents) this ensures that future improvements to `voyager_helpers` can be introduced without requiring that a new version of the Gem be released.