### PR TITLE
skip uri scrubbing for urls with fragment

### DIFF
--- a/marc_to_solr/lib/normal_uri_factory.rb
+++ b/marc_to_solr/lib/normal_uri_factory.rb
@@ -18,7 +18,7 @@ class NormalUriFactory
     # Clean the URL value
     # @param value [String] String value for the URL
     def clean(value)
-      return value if value =~ /#view/
+      return value if value =~ /#.+/
       URI.escape(URI.unescape(value).scrub)
     end
 end

--- a/marc_to_solr/spec/lib/princeton_marc_spec.rb
+++ b/marc_to_solr/spec/lib/princeton_marc_spec.rb
@@ -207,6 +207,12 @@ describe 'From princeton_marc.rb' do
         expect(links).to include('http://www.archivesdirect.amdigital.co.uk/Documents/Details/FO%20424_144' => ['www.archivesdirect.amdigital.co.uk'])
       end
     end
+    context 'with a URL fragment' do
+      let(:url) { 'http://libweb5.princeton.edu/visual_materials/maps/globes-objects/hmc05.html#stella' }
+      it 'preserves fragment' do
+        expect(links).to include('http://libweb5.princeton.edu/visual_materials/maps/globes-objects/hmc05.html#stella' => ['libweb5.princeton.edu'])
+      end
+    end
   end
 
   describe 'standard_no_hash with keys based on the first indicator' do


### PR DESCRIPTION
 A quick fix for #525. URL fragments shouldn't get escaped during the index process.