### PR TITLE
switches catalog-staging core back to voyager test

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -41,12 +41,11 @@ end
 job_type :liberate_latest_staging, "cd :path && :environment_variable=:environment BIBDATA_URL=:bibdata_url SET_URL=:set_url UPDATE_LOCATIONS=:update_locations :bundle_command rake :task --silent :output"
 job_type :liberate_latest_production, "cd :path && :environment_variable=:environment SET_URL=:set_url UPDATE_LOCATIONS=:update_locations :bundle_command rake :task --silent :output"
 
-# 3 updates to catalog-staging per day
-# Currently catalog staging is using Voyager prod which updates 3 times per day
-every 1.day, at: ["2:40am", "11:55am", "8:55pm"], roles: [:cron_staging] do
+# 1 incremental update to catalog-staging per week, from voyager test
+every :sunday, at: "5:15am", roles: [:cron_staging] do
   liberate_latest_staging(
     "liberate:latest",
-    bibdata_url: "https://bibdata.princeton.edu",
+    bibdata_url: "https://bibdata-staging.princeton.edu",
     set_url: ENV["SOLR_URL"],
     update_locations: "true",
     output: "/tmp/cron_log.log"


### PR DESCRIPTION
Reverts #537 so the catalog-staging core can update with the voyager test data. There is a solr collection catalog-production-backup on the solr staging cluster that catalog-staging.princeton.edu can point to if we want to access production data.