### PR TITLE
adds unstem_search fields for subjects, removes combined subject display

### DIFF
--- a/marc_to_solr/lib/traject_config.rb
+++ b/marc_to_solr/lib/traject_config.rb
@@ -735,12 +735,6 @@ to_field 'cumulative_index_finding_aid_display', extract_marc('555|8*|3abcd')
 #    630 XX adfgklmnoprst{v--%}{x--%}{y--%}{z--%} S adfgklmnoprstvxyz
 #    650 XX abc{v--%}{x--%}{z--%}{y--%} S abcvxyz
 #    651 XX a{v--%}{x--%}{y--%}{z--%} S avxyz
-to_field 'subject_display' do |record, accumulator|
-  subjects = process_hierarchy(record, '600|*0|abcdfklmnopqrtvxyz:610|*0|abfklmnoprstvxyz:611|*0|abcdefgklnpqstvxyz:630|*0|adfgklmnoprstvxyz:650|*0|abcvxyz:651|*0|avxyz')
-  sk_subjects = process_hierarchy(record, '650|*7|abcvxyz', ['sk'])
-  accumulator.replace([subjects, sk_subjects].flatten)
-end
-
 to_field 'lc_subject_display' do |record, accumulator|
   subjects = process_hierarchy(record, '600|*0|abcdfklmnopqrtvxyz:610|*0|abfklmnoprstvxyz:611|*0|abcdefgklnpqstvxyz:630|*0|adfgklmnoprstvxyz:650|*0|abcvxyz:651|*0|avxyz')
   accumulator.replace(subjects)
@@ -750,6 +744,13 @@ to_field 'siku_subject_display' do |record, accumulator|
   genres = process_hierarchy(record, '650|*7|abcvxyz', ['sk'])
   accumulator.replace(genres)
 end
+
+# Adds lc and siku subject unstem_search fields
+each_record do |_record, context|
+  context.output_hash['subject_unstem_search'] = context.output_hash['lc_subject_display']
+  context.output_hash['siku_subject_unstem_search'] = context.output_hash['siku_subject_display']
+end
+
 
 # used for the browse lists and hierarchical subject/genre facet
 to_field 'subject_facet' do |record, accumulator|

--- a/marc_to_solr/spec/lib/config_spec.rb
+++ b/marc_to_solr/spec/lib/config_spec.rb
@@ -467,14 +467,17 @@ describe 'From traject_config.rb' do
     end
   end
 
-  describe 'subject fields' do
+  describe 'subject display and unstem fields' do
     let(:s650_lcsh) { { "650"=>{ "ind1"=>"", "ind2"=>"0", "subfields"=>[{ "a"=>"LC Subject" }] } } }
     let(:s650_sk) { { "650"=>{ "ind1"=>"", "ind2"=>"7", "subfields"=>[{ "a"=>"Siku Subject" }, { "2"=>"sk" }] } } }
     let(:s650_exclude) { { "650"=>{ "ind1"=>"", "ind2"=>"7", "subfields"=>[{ "a"=>"Exclude from subject browse" }, { "2"=>"bad" }] } } }
     let(:subject_marc) { @indexer.map_record(MARC::Record.new_from_hash('fields' => [s650_lcsh, s650_sk, s650_exclude], 'leader' => leader)) }
 
-    it 'include the sk subjects but exclude other non-lc subjects' do
-        expect(subject_marc['subject_display']).to match_array(['LC Subject', 'Siku Subject'])
+    it 'include the sk and lc subjects in separate fields, exlcude other subject types' do
+      expect(subject_marc['lc_subject_display']).to match_array(['LC Subject'])
+      expect(subject_marc['subject_unstem_search']).to match_array(['LC Subject'])
+      expect(subject_marc['siku_subject_display']).to match_array(['Siku Subject'])
+      expect(subject_marc['siku_subject_unstem_search']).to match_array(['Siku Subject'])
     end
   end
   describe 'form_genre_display' do


### PR DESCRIPTION
The DSSG approved displaying the Siku and LC subject fields separately so the subject_display field won't need to be used.
Indexes an unstem_search field for these subject fields. Eventually the subject_unstem_search field will include original and modified subject headings (index only fields) as per the "change the subject" project. See #595 for the proposed indexing change.