### PR TITLE
Adds patron group & fixes holding bug

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,12 +46,13 @@ GIT
 
 GIT
   remote: https://github.com/pulibrary/voyager_helpers.git
-  revision: 0d8f633f1fbf258331cbf64baec4ba937f999224
+  revision: 839acb7db247150fded107989a14680a0cc4d8ce
   branch: master
   specs:
-    voyager_helpers (0.7.5)
+    voyager_helpers (0.7.6)
       activesupport (~> 5.1)
       diffy (~> 3.0.7)
+      irb
       marc (~> 1.0)
 
 GEM
@@ -188,6 +189,9 @@ GEM
     httpclient (2.8.3)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
+    io-console (0.5.6)
+    irb (1.2.4)
+      reline (>= 0.0.1)
     iso-639 (0.2.8)
     jaro_winkler (1.5.4)
     jbuilder (2.7.0)
@@ -313,6 +317,8 @@ GEM
       ffi (~> 1.0)
     rdoc (4.3.0)
     redis (4.0.1)
+    reline (0.1.4)
+      io-console (~> 0.5)
     request_store (1.4.1)
       rack (>= 1.4)
     rerun (0.10.0)

--- a/spec/controllers/bibliographic_controller_spec.rb
+++ b/spec/controllers/bibliographic_controller_spec.rb
@@ -137,28 +137,28 @@ RSpec.describe BibliographicController, type: :controller do
       context 'when call number is not handeled by lcsort' do
         before do
           allow(VoyagerHelpers::Liberator).to receive(:get_items_for_bib).and_return(
-            "f" => [{ holding_id: 1137735, call_number: "B785.W54xH6.1973", items: [{ id: 1230549, on_reserve: "N", copy_number: 1, item_sequence_number: 1, temp_location: nil, perm_location: "f", enum: nil, chron: nil, barcode: "32101028648937", due_date: nil, status: ["Not Charged"] }] }]
+            "f" => [{ holding_id: 1137735, call_number: "B785.W54xH6.1973", items: [{ id: 1230549, on_reserve: "N", copy_number: 1, item_sequence_number: 1, temp_location: nil, perm_location: "f", enum: nil, chron: nil, barcode: "32101028648937", due_date: nil, patron_group_charged: "GRAD", status: ["Not Charged"] }] }]
           )
         end
 
         it 'renders a 200 HTTP response and adds a normalized call number for locator' do
           get :bib_items, params: { bib_id: '987479' }, format: 'json'
           expect(response.status).to be 200
-          expect(response.body).to eq("{\"f\":[{\"holding_id\":1137735,\"call_number\":\"B785.W54xH6.1973\",\"items\":[{\"id\":1230549,\"on_reserve\":\"N\",\"copy_number\":1,\"item_sequence_number\":1,\"temp_location\":null,\"perm_location\":\"f\",\"enum\":null,\"chron\":null,\"barcode\":\"32101028648937\",\"due_date\":null,\"status\":[\"Not Charged\"]}],\"sortable_call_number\":\"B.0785.W54xH6.1973\"}]}")
+          expect(response.body).to eq("{\"f\":[{\"holding_id\":1137735,\"call_number\":\"B785.W54xH6.1973\",\"items\":[{\"id\":1230549,\"on_reserve\":\"N\",\"copy_number\":1,\"item_sequence_number\":1,\"temp_location\":null,\"perm_location\":\"f\",\"enum\":null,\"chron\":null,\"barcode\":\"32101028648937\",\"due_date\":null,\"patron_group_charged\":\"GRAD\",\"status\":[\"Not Charged\"]}],\"sortable_call_number\":\"B.0785.W54xH6.1973\"}]}")
         end
       end
 
       context 'when call number is handeled by lcsort' do
         before do
           allow(VoyagerHelpers::Liberator).to receive(:get_items_for_bib).and_return(
-            "f" => [{ holding_id: 1412398, call_number: "UB357.E33.1973", items: [{ id: 1503428, on_reserve: "N", copy_number: 1, item_sequence_number: 1, temp_location: nil, perm_location: "f", enum: nil, chron: nil, barcode: "32101004147094", due_date: nil, status: ["Not Charged", "Missing"] }] }, { holding_id: 5434239, call_number: "UB357.E33.1973", items: [{ id: 4647744, on_reserve: "N", copy_number: 2, item_sequence_number: 1, temp_location: nil, perm_location: "f", enum: nil, chron: nil, barcode: "32101072966698", due_date: nil, status: ["Not Charged"] }] }]
+            "f" => [{ holding_id: 1412398, call_number: "UB357.E33.1973", items: [{ id: 1503428, on_reserve: "N", copy_number: 1, item_sequence_number: 1, temp_location: nil, perm_location: "f", enum: nil, chron: nil, barcode: "32101004147094", due_date: nil, status: ["Not Charged", "Missing"] }] }, { holding_id: 5434239, call_number: "UB357.E33.1973", items: [{ id: 4647744, on_reserve: "N", copy_number: 2, item_sequence_number: 1, temp_location: nil, perm_location: "f", enum: nil, chron: nil, barcode: "32101072966698", due_date: nil, patron_group_charged: "GRAD", status: ["Not Charged"] }] }]
           )
         end
 
         it 'renders a 200 HTTP response and adds a normalized call number for locator' do
           get :bib_items, params: { bib_id: '1234567' }, format: 'json'
           expect(response.status).to be 200
-          expect(response.body).to eq("{\"f\":[{\"holding_id\":1412398,\"call_number\":\"UB357.E33.1973\",\"items\":[{\"id\":1503428,\"on_reserve\":\"N\",\"copy_number\":1,\"item_sequence_number\":1,\"temp_location\":null,\"perm_location\":\"f\",\"enum\":null,\"chron\":null,\"barcode\":\"32101004147094\",\"due_date\":null,\"status\":[\"Not Charged\",\"Missing\"]}],\"sortable_call_number\":\"UB.0357.E33.1973\"},{\"holding_id\":5434239,\"call_number\":\"UB357.E33.1973\",\"items\":[{\"id\":4647744,\"on_reserve\":\"N\",\"copy_number\":2,\"item_sequence_number\":1,\"temp_location\":null,\"perm_location\":\"f\",\"enum\":null,\"chron\":null,\"barcode\":\"32101072966698\",\"due_date\":null,\"status\":[\"Not Charged\"]}],\"sortable_call_number\":\"UB.0357.E33.1973\"}]}")
+          expect(response.body).to eq("{\"f\":[{\"holding_id\":1412398,\"call_number\":\"UB357.E33.1973\",\"items\":[{\"id\":1503428,\"on_reserve\":\"N\",\"copy_number\":1,\"item_sequence_number\":1,\"temp_location\":null,\"perm_location\":\"f\",\"enum\":null,\"chron\":null,\"barcode\":\"32101004147094\",\"due_date\":null,\"status\":[\"Not Charged\",\"Missing\"]}],\"sortable_call_number\":\"UB.0357.E33.1973\"},{\"holding_id\":5434239,\"call_number\":\"UB357.E33.1973\",\"items\":[{\"id\":4647744,\"on_reserve\":\"N\",\"copy_number\":2,\"item_sequence_number\":1,\"temp_location\":null,\"perm_location\":\"f\",\"enum\":null,\"chron\":null,\"barcode\":\"32101072966698\",\"due_date\":null,\"patron_group_charged\":\"GRAD\",\"status\":[\"Not Charged\"]}],\"sortable_call_number\":\"UB.0357.E33.1973\"}]}")
         end
       end
 


### PR DESCRIPTION
closes #704 
updates the voyager_helpers gem:

1. Adds the patron_group_charged https://bibdata-staging.princeton.edu/bibliographic/1234567/items

1. Fixes a bug which was displaying some of the items as suppressed while they were not suppressed when visiting https://bibdata-staging.princeton.edu/bibliographic/1234567/items 

Please see the update in the voyager_helpers gem: https://github.com/pulibrary/voyager_helpers/pull/112/files
