### PR TITLE
Adds hathi access oclc lookup, updates bibid lookup

### DIFF
--- a/app/controllers/hathi_controller.rb
+++ b/app/controllers/hathi_controller.rb
@@ -1,5 +1,8 @@
 class HathiController < ApplicationController
 
+  # ToDo Remove hathi_access_bib_status when requests and Orangelight will be updated 
+  # with the new bib_id and oclc route hathi#hathi_access
+  # Also remove it from the routes.rb
   def hathi_access_bib_status
     if params[:bib_id]
       @record = HathiAccess.where(bibid: params[:bib_id])

--- a/app/controllers/hathi_controller.rb
+++ b/app/controllers/hathi_controller.rb
@@ -3,12 +3,12 @@ class HathiController < ApplicationController
   # ToDo Remove hathi_access_bib_status when requests and Orangelight will be updated 
   # with the new bib_id and oclc route hathi#hathi_access
   # Also remove it from the routes.rb
-  def hathi_access_bib_status
-    if params[:bib_id]
-      @record = HathiAccess.where(bibid: params[:bib_id])
-      render json: @record, except: [:id, :created_at, :updated_at]
-    end
-  end
+  # def hathi_access_bib_status
+#     if params[:bib_id]
+#       @record = HathiAccess.where(bibid: params[:bib_id])
+#       render json: @record, except: [:id, :created_at, :updated_at]
+#     end
+#   end
 
   def hathi_access
     return hathi_access_bib if params[:bib_id]

--- a/app/controllers/hathi_controller.rb
+++ b/app/controllers/hathi_controller.rb
@@ -1,11 +1,18 @@
 class HathiController < ApplicationController
 
-  def hathi_access
-    return hathi_access_bib_status if params[:bib_id]
-    return hathi_access_oclc_status if params[:oclc]
+  def hathi_access_bib_status
+    if params[:bib_id]
+      @record = HathiAccess.where(bibid: params[:bib_id])
+      render json: @record, except: [:id, :created_at, :updated_at]
+    end
   end
 
-  def hathi_access_bib_status
+  def hathi_access
+    return hathi_access_bib if params[:bib_id]
+    return hathi_access_oclc if params[:oclc]
+  end
+
+  def hathi_access_bib
     @record = HathiAccess.where(bibid: params[:bib_id])
     if @record.present?
       render json: @record, except: [:id, :created_at, :updated_at]
@@ -14,7 +21,7 @@ class HathiController < ApplicationController
     end
   end
 
-  def hathi_access_oclc_status
+  def hathi_access_oclc
     @record = HathiAccess.where(oclc_number: params[:oclc])
     if @record.present?
       render json: @record, except: [:id, :created_at, :updated_at]

--- a/app/controllers/hathi_controller.rb
+++ b/app/controllers/hathi_controller.rb
@@ -1,9 +1,31 @@
 class HathiController < ApplicationController
 
+  def hathi_access
+    return hathi_access_bib_status if params[:bib_id]
+    return hathi_access_oclc_status if params[:oclc]
+  end
+
   def hathi_access_bib_status
-    if params[:bib_id]
-      @hathi_record = HathiAccess.where(bibid: params[:bib_id]).select(:bibid,:status,:origin,:oclc_number)
-      render json: @hathi_record
+    @record = HathiAccess.where(bibid: params[:bib_id])
+    if @record.present?
+      render json: @record, except: [:id, :created_at, :updated_at]
+    else
+      status_404
     end
   end
+
+  def hathi_access_oclc_status
+    @record = HathiAccess.where(oclc_number: params[:oclc])
+    if @record.present?
+      render json: @record, except: [:id, :created_at, :updated_at]
+    else
+      status_404
+    end
+  end
+
+  def status_404
+    render json: @record, status: 404
+  end
+
 end
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,10 +34,10 @@ Rails.application.routes.draw do
   get '/courses', to: 'courses#index', defaults: { format: :json }
   get "/bib_ids", to: 'courses#bibs', defaults: { format: :json }
   
-  # remove hathi#hathi_access_bib_status after we update the requests and orangelight
-
-  get '/hathi/access', to: 'hathi#hathi_access', defaults: { format: :json }
+  # ToDo Remove hathi#hathi_access_bib_status when requests and orangelight will be updated with the new route hathi#hathi_access
   get '/hathi/access', to: 'hathi#hathi_access_bib_status', defaults: { format: :json }
+  get '/hathi/access', to: 'hathi#hathi_access', defaults: { format: :json }
+
   require 'sidekiq/web'
   authenticate :user do
     mount Sidekiq::Web => '/sidekiq'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,7 @@ Rails.application.routes.draw do
   get '/courses', to: 'courses#index', defaults: { format: :json }
   get "/bib_ids", to: 'courses#bibs', defaults: { format: :json }
 
-  get '/hathi/access', to: 'hathi#hathi_access_bib_status', defaults: { format: :json }
+  get '/hathi/access', to: 'hathi#hathi_access', defaults: { format: :json }
 
   require 'sidekiq/web'
   authenticate :user do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,9 +33,11 @@ Rails.application.routes.draw do
 
   get '/courses', to: 'courses#index', defaults: { format: :json }
   get "/bib_ids", to: 'courses#bibs', defaults: { format: :json }
+  
+  # remove hathi#hathi_access_bib_status after we update the requests and orangelight
 
   get '/hathi/access', to: 'hathi#hathi_access', defaults: { format: :json }
-
+  get '/hathi/access', to: 'hathi#hathi_access_bib_status', defaults: { format: :json }
   require 'sidekiq/web'
   authenticate :user do
     mount Sidekiq::Web => '/sidekiq'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,10 +33,10 @@ Rails.application.routes.draw do
 
   get '/courses', to: 'courses#index', defaults: { format: :json }
   get "/bib_ids", to: 'courses#bibs', defaults: { format: :json }
-  
-  # ToDo Remove hathi#hathi_access_bib_status when requests and orangelight will be updated with the new route hathi#hathi_access
-  get '/hathi/access', to: 'hathi#hathi_access_bib_status', defaults: { format: :json }
+
   get '/hathi/access', to: 'hathi#hathi_access', defaults: { format: :json }
+  # ToDo Remove hathi#hathi_access_bib_status when requests and orangelight will be updated with the new route hathi#hathi_access
+  # get '/hathi/access', to: 'hathi#hathi_access_bib_status', defaults: { format: :json }
 
   require 'sidekiq/web'
   authenticate :user do

--- a/spec/controllers/hathi_controller_spec.rb
+++ b/spec/controllers/hathi_controller_spec.rb
@@ -10,33 +10,33 @@ RSpec.describe HathiController, type: :controller do
   end
 
   # ToDo Remove this test when the old route hathi#hathi_access_bib_status will be removed
-  describe '#hathi_access_bib_status' do
-    context 'when a bibid is provided' do
-      context 'when the bib exists' do
-        let(:bib_id) { "100" }
-        it 'returns an array of records with the same bib' do
-          get :hathi_access_bib_status, params: { bib_id: bib_id }
-
-          expect(JSON.parse(response.body).count).to eq 2
-          expect(JSON.parse(response.body)[0]["oclc_number"]).to eq("1234567")
-          expect(JSON.parse(response.body)[0]["bibid"]).to eq("100")
-          expect(JSON.parse(response.body)[0]["status"]).to eq("DENY")
-          expect(JSON.parse(response.body)[0]["origin"]).to eq("CUL")
-          expect(JSON.parse(response.body)[1]["oclc_number"]).to eq("2243200")
-          expect(JSON.parse(response.body)[1]["bibid"]).to eq("100")
-          expect(JSON.parse(response.body)[1]["status"]).to eq("ALLOW")
-          expect(JSON.parse(response.body)[1]["origin"]).to eq("CUL")
-          expect(response.status).to eq(200)
-        end
-      end
-      context 'when the bib does not exist' do
-        let(:bib_id) { "200" }
-        it 'returns an empty string' do
-          expect(response.body).to eq("")
-        end
-      end
-    end
-  end
+  # describe '#hathi_access_bib_status' do
+#     context 'when a bibid is provided' do
+#       context 'when the bib exists' do
+#         let(:bib_id) { "100" }
+#         it 'returns an array of records with the same bib' do
+#           get :hathi_access_bib_status, params: { bib_id: bib_id }
+#
+#           expect(JSON.parse(response.body).count).to eq 2
+#           expect(JSON.parse(response.body)[0]["oclc_number"]).to eq("1234567")
+#           expect(JSON.parse(response.body)[0]["bibid"]).to eq("100")
+#           expect(JSON.parse(response.body)[0]["status"]).to eq("DENY")
+#           expect(JSON.parse(response.body)[0]["origin"]).to eq("CUL")
+#           expect(JSON.parse(response.body)[1]["oclc_number"]).to eq("2243200")
+#           expect(JSON.parse(response.body)[1]["bibid"]).to eq("100")
+#           expect(JSON.parse(response.body)[1]["status"]).to eq("ALLOW")
+#           expect(JSON.parse(response.body)[1]["origin"]).to eq("CUL")
+#           expect(response.status).to eq(200)
+#         end
+#       end
+#       context 'when the bib does not exist' do
+#         let(:bib_id) { "200" }
+#         it 'returns an empty string' do
+#           expect(response.body).to eq("")
+#         end
+#       end
+#     end
+#   end
 
   describe '#hathi_access' do
     context 'when a bibid is provided' do

--- a/spec/controllers/hathi_controller_spec.rb
+++ b/spec/controllers/hathi_controller_spec.rb
@@ -8,6 +8,33 @@ RSpec.describe HathiController, type: :controller do
      FactoryBot.create(:hathi_access, status: "DENY", oclc_number: "2243109", bibid: "1000", origin: "CUL" )
      FactoryBot.create(:hathi_access, status: "ALLOW", oclc_number: "2243109", bibid: "1000", origin: "CUL" )
   end
+  describe '#hathi_access_bib_status' do
+    context 'when a bibid is provided' do
+      context 'when the bib exists' do
+        let(:bib_id) { "100" }
+        it 'returns an array of records with the same bib' do
+          get :hathi_access_bib_status, params: { bib_id: bib_id }
+
+          expect(JSON.parse(response.body).count).to eq 2
+          expect(JSON.parse(response.body)[0]["oclc_number"]).to eq("1234567")
+          expect(JSON.parse(response.body)[0]["bibid"]).to eq("100")
+          expect(JSON.parse(response.body)[0]["status"]).to eq("DENY")
+          expect(JSON.parse(response.body)[0]["origin"]).to eq("CUL")
+          expect(JSON.parse(response.body)[1]["oclc_number"]).to eq("2243200")
+          expect(JSON.parse(response.body)[1]["bibid"]).to eq("100")
+          expect(JSON.parse(response.body)[1]["status"]).to eq("ALLOW")
+          expect(JSON.parse(response.body)[1]["origin"]).to eq("CUL")
+          expect(response.status).to eq(200)
+        end
+      end
+      context 'when the bib does not exist' do
+        let(:bib_id) { "200" }
+        it 'returns an empty string' do
+          expect(response.body).to eq("")
+        end
+      end
+    end
+  end
 
   describe '#hathi_access' do
     context 'when a bibid is provided' do

--- a/spec/controllers/hathi_controller_spec.rb
+++ b/spec/controllers/hathi_controller_spec.rb
@@ -5,14 +5,16 @@ RSpec.describe HathiController, type: :controller do
   before do
      FactoryBot.create(:hathi_access)
      FactoryBot.create(:hathi_access, status: "ALLOW", oclc_number: "2243200" )
+     FactoryBot.create(:hathi_access, status: "DENY", oclc_number: "2243109", bibid: "1000", origin: "CUL" )
+     FactoryBot.create(:hathi_access, status: "ALLOW", oclc_number: "2243109", bibid: "1000", origin: "CUL" )
   end
 
-  describe '#hathi_access_bib_status' do
+  describe '#hathi_access' do
     context 'when a bibid is provided' do
       context 'when the bib exists' do
         let(:bib_id) { "100" }
         it 'returns an array of records with the same bib' do
-          get :hathi_access_bib_status, params: { bib_id: bib_id }
+          get :hathi_access, params: { bib_id: bib_id }
 
           expect(JSON.parse(response.body).count).to eq 2
           expect(JSON.parse(response.body)[0]["oclc_number"]).to eq("1234567")
@@ -23,13 +25,51 @@ RSpec.describe HathiController, type: :controller do
           expect(JSON.parse(response.body)[1]["bibid"]).to eq("100")
           expect(JSON.parse(response.body)[1]["status"]).to eq("ALLOW")
           expect(JSON.parse(response.body)[1]["origin"]).to eq("CUL")
+          expect(JSON.parse(response.body)[0]["id"]).to be_falsey
+          expect(JSON.parse(response.body)[0]["created_at"]).to be_falsey
+          expect(JSON.parse(response.body)[0]["updated_at"]).to be_falsey
           expect(response.status).to eq(200)
         end
       end
       context 'when the bib does not exist' do
         let(:bib_id) { "200" }
-        it 'returns an empty string' do
-          expect(response.body).to eq("")
+        it 'returns an empty array' do
+          get :hathi_access, params: { bib_id: bib_id }
+
+          expect(response.body).to eq("[]")
+          expect(response.status).to eq(404)
+        end
+      end
+    end
+    context 'when an oclc is provided' do
+      context 'when the oclc exists' do
+        let(:oclc_number) { "2243109" }
+        it 'returns an array of records with the same oclc' do
+          get :hathi_access, params: { oclc: oclc_number }
+
+          expect(JSON.parse(response.body).count).to eq 2
+          expect(JSON.parse(response.body)[0]["oclc_number"]).to eq("2243109")
+          expect(JSON.parse(response.body)[0]["bibid"]).to eq("1000")
+          expect(JSON.parse(response.body)[0]["status"]).to eq("DENY")
+          expect(JSON.parse(response.body)[0]["origin"]).to eq("CUL")
+          expect(JSON.parse(response.body)[1]["oclc_number"]).to eq("2243109")
+          expect(JSON.parse(response.body)[1]["bibid"]).to eq("1000")
+          expect(JSON.parse(response.body)[1]["status"]).to eq("ALLOW")
+          expect(JSON.parse(response.body)[1]["origin"]).to eq("CUL")
+          expect(JSON.parse(response.body)[0]["id"]).to be_falsey
+          expect(JSON.parse(response.body)[0]["created_at"]).to be_falsey
+          expect(JSON.parse(response.body)[0]["updated_at"]).to be_falsey
+          expect(response.status).to eq(200)
+        end
+      end
+      context 'when the oclc does not exist' do
+        let(:oclc_number) { "200" }
+        it 'returns an empty array' do
+          get :hathi_access, params: { oclc: oclc_number }
+
+          expect(response.body).to eq("[]")
+          expect(response.status).to eq(404)
+          expect(response.status).not_to eq(200)
         end
       end
     end

--- a/spec/controllers/hathi_controller_spec.rb
+++ b/spec/controllers/hathi_controller_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe HathiController, type: :controller do
      FactoryBot.create(:hathi_access, status: "DENY", oclc_number: "2243109", bibid: "1000", origin: "CUL" )
      FactoryBot.create(:hathi_access, status: "ALLOW", oclc_number: "2243109", bibid: "1000", origin: "CUL" )
   end
+
+  # ToDo Remove this test when the old route hathi#hathi_access_bib_status will be removed
   describe '#hathi_access_bib_status' do
     context 'when a bibid is provided' do
       context 'when the bib exists' do


### PR DESCRIPTION
closes #760 
closes #767

1. `http://localhost:3000/hathi/access?bib_id=100000`
=> `[{"oclc_number":"6092569","bibid":"100000","status":"DENY","origin":"CUL"}]`
1. `http://localhost:3000/hathi/access?oclc=2243109`
=> `[{"oclc_number":"2243109","bibid":"100","status":"ALLOW","origin":"CUL"},{"oclc_number":"2243109","bibid":"100","status":"DENY","origin":"CUL"}]`

