### PR TITLE
Fixes to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
       - run: gem install bundler -v '~> 2.0'
       - run:
           name: Install dependencies
-          command: bundle install --path=vendor/bundle --without development production --jobs 4 --retry 3
+          command: bundle install --path=vendor/bundle --jobs 4 --retry 3
       - save_cache:
           key: marc_liberation-{{ checksum "Gemfile.lock" }}-2
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,10 @@ jobs:
           command: node -v
       - restore_cache:
           keys:
-          - marc_liberation-{{ checksum "Gemfile.lock" }}-2
+            # this cache is never found because ruby-oci8 isn't included in ci
+            - marc_liberation-{{ checksum "Gemfile.lock" }}-2
+            # use a partial cache restore
+            - marc_liberation-
       - run:
           name: Install phantomjs
           command: sudo apt install phantomjs
@@ -42,12 +45,11 @@ jobs:
       - run: gem install bundler -v '~> 2.0'
       - run:
           name: Install dependencies
-          command: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --without development production --jobs 4 --retry 3
+          command: bundle install --path=vendor/bundle --without development production --jobs 4 --retry 3
       - save_cache:
           key: marc_liberation-{{ checksum "Gemfile.lock" }}-2
           paths:
-            - vendor/bundle 
-
+            - vendor/bundle
       - run:
           name: Configure location display
           command: cp -v marc_to_solr/translation_maps/location_display.rb.tmpl marc_to_solr/translation_maps/location_display.rb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,9 +34,9 @@ jobs:
       - restore_cache:
           keys:
             # this cache is never found because ruby-oci8 isn't included in ci
-            - marc_liberation-{{ checksum "Gemfile.lock" }}-2
+            - v2-marc_liberation-{{ checksum "Gemfile.lock" }}
             # use a partial cache restore
-            - marc_liberation-
+            - v2-marc_liberation-
       - run:
           name: Install phantomjs
           command: sudo apt install phantomjs
@@ -47,7 +47,7 @@ jobs:
           name: Install dependencies
           command: bundle install --path=vendor/bundle --jobs 4 --retry 3
       - save_cache:
-          key: marc_liberation-{{ checksum "Gemfile.lock" }}-2
+          key: v2-marc_liberation-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
       - run:

--- a/config/authz.yml
+++ b/config/authz.yml
@@ -6,6 +6,7 @@ development:
 
 test:
   <<: *default
+  netids: admin123
 
 production:
   <<: *default

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,4 +36,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Don't use sidekiq in tests
+  config.active_job.queue_adapter = :test
 end

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -4,7 +4,6 @@ task :spec do
   if Rails.env.development? || Rails.env.staging?
     ENV['FIGGY_ARK_CACHE_PATH'] = 'marc_to_solr/spec/fixtures/figgy_ark_cache'
     ENV['TRAJECT_CONFIG'] = 'marc_to_solr/lib/traject_config.rb'
-    ENV['BIBDATA_ADMIN_NETIDS'] = 'admin123'
     ENV['HATHI_OUTPUT_DIR'] = 'marc_to_solr/spec/fixtures/'
     sh "rspec spec marc_to_solr/spec"
   end

--- a/spec/controllers/bibliographic_controller_spec.rb
+++ b/spec/controllers/bibliographic_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe BibliographicController, type: :controller do
     context 'when authenticated as an administrator' do
       login_admin
 
-      it 'enqueues an Index Job for a bib. record using a bib. ID', unless: !ENV['CI'].nil? do
+      it 'enqueues an Index Job for a bib. record using a bib. ID' do
         post :update, params: { bib_id: bib_id }
         expect(response).to redirect_to(index_path)
         expect(flash[:notice]).to be_present


### PR DESCRIPTION
Move the admin user configuration from env to yaml
Allow bibliographic_controller#update specs to run/pass in CI (this increases coverage a bit)
Ensure bundle cache is retrieved in ci (this decreases test runs from 12-15 min down to 2 min)

fixes #779