### PR TITLE
Save access as lower case

### DIFF
--- a/app/models/campus_access.rb
+++ b/app/models/campus_access.rb
@@ -1,6 +1,11 @@
 require 'csv'
 
 class CampusAccess < ActiveRecord::Base
+  def initialize( attributes)
+    attributes[:uid] = attributes[:uid]&.downcase
+    super(attributes)
+  end
+
   class << self
     def has_access?(uid)
       where(uid: uid).count.positive?
@@ -10,7 +15,7 @@ class CampusAccess < ActiveRecord::Base
     def to_csv
       ::CSV.generate(headers: false) do |csv|
         all.find_each do |user|
-          csv << ["#{user.uid.downcase}@princeton.edu"]
+          csv << ["#{user.uid}@princeton.edu"]
         end
       end
     end

--- a/spec/models/campus_access_spec.rb
+++ b/spec/models/campus_access_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe CampusAccess, type: :model do
       f=File.expand_path("../../fixtures/access.xlsx",__FILE__)
       described_class.load_access(f)
       expect(CampusAccess.count).to eq(4)
-      expect(CampusAccess.all.map(&:uid)).to contain_exactly("TEST1", "TEST2", "TEST3", "TEST6")
+      expect(CampusAccess.all.map(&:uid)).to contain_exactly("test1", "test2", "test3", "test6")
     end
 
     it "leaves the database alone if the file does not exist" do


### PR DESCRIPTION
Realized that all users were being disallowed since the OIT file has ids in upper case and our queries are in lower case

fixes #798