### PR TITLE
Adds pagination on the events page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ gem 'turbolinks'
 gem 'uglifier', '>= 1.3.0'
 gem 'voyager_helpers', github: "pulibrary/voyager_helpers", branch: 'master'
 gem 'whenever', "~> 0.10"
+gem 'will_paginate', '~> 3.3.0'
 gem 'yaml_db', '~> 0.7.0'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -467,6 +467,7 @@ GEM
     websocket-extensions (0.1.5)
     whenever (0.10.0)
       chronic (>= 0.6.3)
+    will_paginate (3.3.0)
     xml-simple (1.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
@@ -545,6 +546,7 @@ DEPENDENCIES
   webdrivers
   webmock
   whenever (~> 0.10)
+  will_paginate (~> 3.3.0)
   yaml_db (~> 0.7.0)
 
 BUNDLED WITH

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -5,7 +5,7 @@ class EventsController < ApplicationController
   respond_to :html, :json
 
   def index
-    @events = Event.all
+    @events = Event.paginate(page: params[:page], per_page: 50).order('id DESC')
     respond_with(@events)
   end
 

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -35,3 +35,5 @@
     <% end %>
   </tbody>
 </table>
+
+<%= will_paginate @events %>

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe EventsController do
+  describe "#index" do
+    render_views
+    before do
+      create_list(:event, 51)
+    end
+
+    context "with more than 50 records" do
+      it "paginates records" do
+        get :index
+        expect(response.body).to have_xpath("//*[@class='pagination']//a[text()='2']")
+        expect(response).to have_http_status(200)
+      end
+
+      it "has a second page with 1 record" do
+        get(:index, params: { page: 2 })
+        expect(response).to have_http_status(200)
+        expect(response.body).to have_xpath("//tbody//tr", count: 1)
+      end
+    end
+  end
+end

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :event do
+    start Time.now
+    finish Time.now + 180
+    success true
+  end
+end


### PR DESCRIPTION
Adds pagination on the events page. Displays 50 records per page.
Adds will_paginate gem
FactoryBot for event,
events_controller_spec

fixes part of #690 
