### PR TITLE
Remove index update crons

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -23,50 +23,6 @@ every 1.day, at: '3:00am' do
   rake "liberate:arks:clear_and_seed_cache"
 end
 
-# check voyager for updates 3 times per day in prod; 1nce per week in staging
-every 1.day, at: ["10:10am", "2:10pm", "10:35pm"], roles: [:cron_production] do
-  rake "marc_liberation:get_changes", output: "/tmp/cron_log.log"
-end
-
-every :sunday, at: "2:30am", roles: [:cron_staging] do
-  rake "marc_liberation:get_changes", output: "/tmp/cron_log.log"
-end
-
-# proxy the liberate:latest task so we can set env vars
-job_type :liberate_latest_staging, "cd :path && :environment_variable=:environment BIBDATA_URL=:bibdata_url SET_URL=:set_url UPDATE_LOCATIONS=:update_locations :bundle_command rake :task --silent :output"
-job_type :liberate_latest_production, "cd :path && :environment_variable=:environment SET_URL=:set_url UPDATE_LOCATIONS=:update_locations :bundle_command rake :task --silent :output"
-
-# 1 incremental update to catalog-staging per week, from voyager test
-every :sunday, at: "5:15am", roles: [:cron_staging] do
-  liberate_latest_staging(
-    "liberate:latest",
-    bibdata_url: "https://bibdata-staging.princeton.edu",
-    set_url: ENV["SOLR_URL"],
-    update_locations: "true",
-    output: "/tmp/cron_log.log"
-  )
-end
-
-# 3 updates to catalog-production per day
-every 1.day, at: ["12:40am", "10:55am", "2:55pm"], roles: [:cron_production] do
-  liberate_latest_production(
-    "liberate:latest",
-    set_url: ENV["SOLR_URL"],
-    update_locations: "true",
-    output: "/tmp/daily_updates.log"
-  )
-end
-
-# 3 updates to catalog-rebuild per day on Solr staging cluster
-every 1.day, at: ["1:00am", "11:30am", "3:30pm"], roles: [:cron_production] do
-  liberate_latest_production(
-    "liberate:latest",
-    set_url: ENV["SOLR_REINDEX_URL"],
-    update_locations: "true",
-    output: "/tmp/daily_updates.log"
-  )
-end
-
 # Daily racap / partner jobs
 # every 1.day, at: "3:00pm", roles: [:cron_production] do
 #   rake "marc_liberation:recap_dump", output: "/tmp/cron_log.log"


### PR DESCRIPTION
These will be replaced by new behavior in the AwsSqsPoller to handle
incremental update webhook events, and are causing honeybadger errors

closes #1028
refs #927
refs #809