### PR TITLE
Start lando with shorter `rake servers:start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Note: You need to have PostgreSQL installed in your machine and available in you
 
 ### Setup server
 1. Install Lando from https://github.com/lando/lando/releases (at least 3.0.0-rrc.2)
-1. To start: `bundle exec rake marc_liberation:server:start`
+1. To start: `bundle exec rake servers:start`
 1. For testing:
    - `bundle exec rspec`
 1. For development:
    - `bundle exec rails server`
    - Access marc_liberation at http://localhost:3000/
-1. To stop: `bundle exec rake marc_liberation:server:stop` or `lando stop`
+1. To stop: `bundle exec rake servers:stop` or `lando stop`
 
 ## Alma
 

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,24 +1,24 @@
-namespace :marc_liberation do
-  namespace :server do
-    task initialize: :environment do
-      Rake::Task["db:create"].invoke
-      Rake::Task["db:migrate"].invoke
-      Rake::Task["db:seed"].invoke
-    end
-
-    desc "Start the Apache Solr and PostgreSQL container services using Lando."
-    task start: :environment do
-      system("lando start")
-      system("rake marc_liberation:server:initialize")
-      LocationMapsGeneratorService.generate_from_templates
-    end
-
-    desc "Stop the Lando Apache Solr and PostgreSQL container services."
-    task stop: :environment do
-      system("lando stop")
-    end
+namespace :servers do
+  task initialize: :environment do
+    Rake::Task["db:create"].invoke
+    Rake::Task["db:migrate"].invoke
+    Rake::Task["db:seed"].invoke
   end
 
+  desc "Start the Apache Solr and PostgreSQL container services using Lando."
+  task start: :environment do
+    system("lando start")
+    system("rake marc_liberation:server:initialize")
+    LocationMapsGeneratorService.generate_from_templates
+  end
+
+  desc "Stop the Lando Apache Solr and PostgreSQL container services."
+  task stop: :environment do
+    system("lando stop")
+  end
+end
+
+namespace :marc_liberation do
   desc "Populate holding location values from database."
   task process_locations: :environment do
     LocationMapsGeneratorService.generate


### PR DESCRIPTION
was `rake marc_liberation:server:start` -- note that `servers` has also
been pluralized since it runs multiple dev and test services

closes #1025