### PR TITLE
Lando solrconfig_xml 

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -37,7 +37,7 @@ namespace :server do
     end
     namespace :configs do
       desc "Updates solr config files from github"
-      task :update, [:solr_dir] => :environment do |_t, args|
+      task :update, [:solr_dir, :config_path] => :environment do |_t, args|
         solr_dir = args[:solr_dir] || Rails.root.join("solr")
         config_path = args[:config_path] || "catalog-production"
 

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -39,18 +39,19 @@ namespace :server do
       desc "Updates solr config files from github"
       task :update, [:solr_dir] => :environment do |_t, args|
         solr_dir = args[:solr_dir] || Rails.root.join("solr")
+        config_path = args[:config_path] || "catalog-production"
 
         ["_rest_managed.json", "admin-extra.html", "elevate.xml",
          "mapping-ISOLatin1Accent.txt", "protwords.txt", "schema.xml",
          "scripts.conf", "solrconfig.xml", "spellings.txt", "stopwords.txt",
          "stopwords_en.txt", "synonyms.txt"].each do |file|
-           response = Faraday.get url_for_file(file)
+           response = Faraday.get url_for_file(file, config_path)
            File.open(File.join(solr_dir, "conf", file), "wb") { |f| f.write(response.body) } if response.success?
          end
       end
 
-      def url_for_file(file)
-        "https://raw.githubusercontent.com/pulibrary/pul_solr/master/solr_configs/catalog-production/conf/#{file}"
+      def url_for_file(file, config_path)
+        "https://raw.githubusercontent.com/pulibrary/pul_solr/master/solr_configs/#{config_path}/conf/#{file}"
       end
     end
   end


### PR DESCRIPTION
Allows the Rake task to update Solr configs to indicate a path to use (e.g. `catalog-production` vs `catalog-staging`) to determine what Solr configuration to download from GitHub. If no parameter is given it uses `catalog-production` as the code used to do before.

Sample of usage: 

```
bundle exec rake server:solr:configs:update[,catalog-staging]
```

The reason for this PR is to be able to pull down config files from environments other than production to the local machine and test them, for example to address issue #1019

We should merge PR https://github.com/pulibrary/pul_solr/pull/253 before we can test this one.