### PR TITLE
Point to correct branch (main)

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -51,7 +51,7 @@ namespace :server do
       end
 
       def url_for_file(file, config_path)
-        "https://raw.githubusercontent.com/pulibrary/pul_solr/master/solr_configs/#{config_path}/conf/#{file}"
+        "https://raw.githubusercontent.com/pulibrary/pul_solr/main/solr_configs/#{config_path}/conf/#{file}"
       end
     end
   end


### PR DESCRIPTION
Uses `main` branch instead of `master` to pull the files.

This is part of https://github.com/pulibrary/marc_liberation/issues/1019

Notice that the content referenced in main vs master is in fact **different**:

https://github.com/pulibrary/pul_solr/blob/master/solr_configs/catalog-staging/conf/solrconfig.xml
https://github.com/pulibrary/pul_solr/blob/main/solr_configs/catalog-staging/conf/solrconfig.xml