### PR TITLE
Strip non-numeric tags from SCSB barcode response.

### DIFF
--- a/app/adapters/alma_adapter/marc_response.rb
+++ b/app/adapters/alma_adapter/marc_response.rb
@@ -53,6 +53,18 @@ class AlmaAdapter
         holding = ::AlmaAdapter::AlmaHolding.for(holding, recap: recap)
         marc_record.fields.concat(holding.marc_record_enrichment)
       end
+
+      # Strips non-numeric tags for ReCAP, whose parser can't handle them.
+      # Integer() is faster than to_i, per
+      # https://stackoverflow.com/questions/5661466/test-if-string-is-a-number-in-ruby-on-rails
+      def strip_non_numeric!
+        marc_record.fields.delete_if do |field|
+          Integer(field.tag)
+          false
+        rescue
+          true
+        end
+      end
     end
 
     private

--- a/app/controllers/barcode_controller.rb
+++ b/app/controllers/barcode_controller.rb
@@ -31,6 +31,7 @@ class BarcodeController < ApplicationController
         bib_record.enrich_with_item(item)
         bib_record.delete_conflicting_holding_data!
         bib_record.enrich_with_holding(holding, recap: true)
+        bib_record.strip_non_numeric!
       end
       if records == []
         render plain: "Barcode #{params[:barcode]} not found.", status: 404

--- a/spec/controllers/barcode_controller_spec.rb
+++ b/spec/controllers/barcode_controller_spec.rb
@@ -36,6 +36,9 @@ RSpec.describe BarcodeController, type: :controller do
         expect(record["856"].as_json).to eq voyager_comparison["856"].as_json
         # Ensure 959 is correct (empty)
         expect(record["959"]).to be_nil
+        # Ensure there are no non-numeric fields
+        # ReCAP's parser can't handle them.
+        expect(record.fields.map { |x| format("%03d", x.tag.to_i) }).to contain_exactly(*record.fields.map(&:tag))
       end
 
       it "enriches a bound-with item with multiple bibs it's attached to" do


### PR DESCRIPTION
Closes #1062

## Implementation Note

I considered just not asking for E_AVAIL/P_AVAIL, etc, so these fields wouldn't be in the requested resource in the first place, but this seemed so easy to parse and write that seemed silly, when otherwise we'd have to manage multiple layers of fixtures and deciding whether to ask for those fields or not.