### PR TITLE
Uses catalog-production-alt by default

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -39,7 +39,7 @@ namespace :server do
       desc "Updates solr config files from github"
       task :update, [:solr_dir, :config_path] => :environment do |_t, args|
         solr_dir = args[:solr_dir] || Rails.root.join("solr")
-        config_path = args[:config_path] || "catalog-production"
+        config_path = args[:config_path] || "catalog-production-alt"
 
         ["_rest_managed.json", "admin-extra.html", "elevate.xml",
          "mapping-ISOLatin1Accent.txt", "protwords.txt", "schema.xml",

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -425,11 +425,15 @@
         <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([\p{InHangul_Jamo}\p{InHangul_Compatibility_Jamo}\p{InHangul_Syllables}][\p{InBopomofo}\p{InBopomofo_Extended}\p{InCJK_Compatibility}\p{InCJK_Compatibility_Forms}\p{InCJK_Compatibility_Ideographs}\p{InCJK_Compatibility_Ideographs_Supplement}\p{InCJK_Radicals_Supplement}\p{InCJK_Symbols_And_Punctuation}\p{InCJK_Unified_Ideographs}\p{InCJK_Unified_Ideographs_Extension_A}\p{InCJK_Unified_Ideographs_Extension_B}\p{InKangxi_Radicals}\p{InHalfwidth_And_Fullwidth_Forms}\p{InIdeographic_Description_Characters}]*)\s+(?=[\p{InHangul_Jamo}\p{InHangul_Compatibility_Jamo}\p{InHangul_Syllables}\p{InBopomofo}\p{InBopomofo_Extended}\p{InCJK_Compatibility}\p{InCJK_Compatibility_Forms}\p{InCJK_Compatibility_Ideographs}\p{InCJK_Compatibility_Ideographs_Supplement}\p{InCJK_Radicals_Supplement}\p{InCJK_Symbols_And_Punctuation}\p{InCJK_Unified_Ideographs}\p{InCJK_Unified_Ideographs_Extension_A}\p{InCJK_Unified_Ideographs_Extension_B}\p{InKangxi_Radicals}\p{InHalfwidth_And_Fullwidth_Forms}\p{InIdeographic_Description_Characters}])" replacement="$1"/>
         <!-- a korean char guaranteed at the end of the pattern:    pattern="([\p{Hangul}\p{Han}])\s+(?=[\p{Han}\s]*\p{Hangul})" -->
         <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([\p{InHangul_Jamo}\p{InHangul_Compatibility_Jamo}\p{InHangul_Syllables}\p{InBopomofo}\p{InBopomofo_Extended}\p{InCJK_Compatibility}\p{InCJK_Compatibility_Forms}\p{InCJK_Compatibility_Ideographs}\p{InCJK_Compatibility_Ideographs_Supplement}\p{InCJK_Radicals_Supplement}\p{InCJK_Symbols_And_Punctuation}\p{InCJK_Unified_Ideographs}\p{InCJK_Unified_Ideographs_Extension_A}\p{InCJK_Unified_Ideographs_Extension_B}\p{InKangxi_Radicals}\p{InHalfwidth_And_Fullwidth_Forms}\p{InIdeographic_Description_Characters}])\s+(?=[\p{InBopomofo}\p{InBopomofo_Extended}\p{InCJK_Compatibility}\p{InCJK_Compatibility_Forms}\p{InCJK_Compatibility_Ideographs}\p{InCJK_Compatibility_Ideographs_Supplement}\p{InCJK_Radicals_Supplement}\p{InCJK_Symbols_And_Punctuation}\p{InCJK_Unified_Ideographs}\p{InCJK_Unified_Ideographs_Extension_A}\p{InCJK_Unified_Ideographs_Extension_B}\p{InKangxi_Radicals}\p{InHalfwidth_And_Fullwidth_Forms}\p{InIdeographic_Description_Characters}\s]*[\p{InHangul_Jamo}\p{InHangul_Compatibility_Jamo}\p{InHangul_Syllables}])" replacement="$1"/>
+        <charFilter class="edu.stanford.lucene.analysis.ICUCustomTransformCharFilterFactory" id="edu/stanford/lucene/analysis/stanford_cjk_transliterations.txt" />
+        <charFilter class="edu.stanford.lucene.analysis.ICUTransformCharFilterFactory" id="Traditional-Simplified" />
+        <charFilter class="edu.stanford.lucene.analysis.ICUTransformCharFilterFactory" id="Katakana-Hiragana" />
+        <charFilter class="solr.PatternReplaceCharFilterFactory"
+          pattern="([\p{InHiragana}\p{InKatakana}\p{InKatakana_Phonetic_Extensions}])([^\p{InHiragana}\p{InKatakana}\p{InKatakana_Phonetic_Extensions}])"
+          replacement="$1 $2"
+        />
         <tokenizer class="solr.ICUTokenizerFactory" />
         <filter class="solr.CJKWidthFilterFactory"/>
-        <filter class="edu.stanford.lucene.analysis.CJKFoldingFilterFactory"/>
-        <filter class="solr.ICUTransformFilterFactory" id="Traditional-Simplified"/>
-        <filter class="solr.ICUTransformFilterFactory" id="Katakana-Hiragana"/>
         <filter class="solr.ICUFoldingFilterFactory"/>   <!-- NFKC, case folding, diacritics removed -->
         <filter class="solr.CJKBigramFilterFactory" han="false" hiragana="false" katakana="false" hangul="true" outputUnigrams="true" />
       </analyzer>
@@ -742,7 +746,9 @@
 
    <!-- unstemmed fields -->
    <copyField source="title_display" dest="title_unstem_search"/>
-   <copyField source="subject_display" dest="subject_unstem_search"/>
+   <copyField source="lcgft_s" dest="genre_unstem_search"/>
+   <copyField source="aat_s" dest="genre_unstem_search"/>
+   <copyField source="rbgenr_s" dest="genre_unstem_search"/>
    <copyField source="subject_topic_facet" dest="subject_topic_unstem_search"/>
 
 
@@ -856,6 +862,10 @@
    <copyField source="title_245_la" dest="text"/>
    <copyField source="title_la" dest="text"/>
    <copyField source="title_addl_la" dest="text"/>
+
+   <!-- copy notes_index to cjk_notes_copied -->
+   <copyField source="notes_index" dest="cjk_notes_copied"/>
+   <copyField source="notes_index" dest="cjk_text"/>
 
    <!-- copy name to alphaNameSort, a field designed for sorting by name -->
    <!-- <copyField source="name" dest="alphaNameSort"/> -->

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -153,13 +153,13 @@
         <lst><str name="fq">location:Stokes Library</str></lst>
         <lst><str name="fq">location:Video Library</str></lst>
 
-        <lst><str name="fq">cataloged_tdt:[NOW/DAY-7DAYS NOW/DAY+1DAY]</str></lst>
-        <lst><str name="fq">cataloged_tdt:[NOW/DAY-14DAYS NOW/DAY+1DAY]</str></lst>
-        <lst><str name="fq">cataloged_tdt:[NOW/DAY-21DAYS NOW/DAY+1DAY]</str></lst>
-        <lst><str name="fq">cataloged_tdt:[NOW/DAY-1MONTH NOW/DAY+1DAY]</str></lst>
-        <lst><str name="fq">cataloged_tdt:[NOW/DAY-2MONTHS NOW/DAY+1DAY]</str></lst>
-        <lst><str name="fq">cataloged_tdt:[NOW/DAY-3MONTHS NOW/DAY+1DAY]</str></lst>
-        <lst><str name="fq">cataloged_tdt:[NOW/DAY-6MONTHS NOW/DAY+1DAY]</str></lst>
+        <lst><str name="fq">cataloged_tdt:[NOW/DAY-7DAYS TO NOW/DAY+1DAY]</str></lst>
+        <lst><str name="fq">cataloged_tdt:[NOW/DAY-14DAYS TO NOW/DAY+1DAY]</str></lst>
+        <lst><str name="fq">cataloged_tdt:[NOW/DAY-21DAYS TO NOW/DAY+1DAY]</str></lst>
+        <lst><str name="fq">cataloged_tdt:[NOW/DAY-1MONTH TO NOW/DAY+1DAY]</str></lst>
+        <lst><str name="fq">cataloged_tdt:[NOW/DAY-2MONTHS TO NOW/DAY+1DAY]</str></lst>
+        <lst><str name="fq">cataloged_tdt:[NOW/DAY-3MONTHS TO NOW/DAY+1DAY]</str></lst>
+        <lst><str name="fq">cataloged_tdt:[NOW/DAY-6MONTHS TO NOW/DAY+1DAY]</str></lst>
 
         <lst><str name="fq">language_facet:English</str></lst>
         <lst><str name="fq">language_facet:German</str></lst>
@@ -269,7 +269,9 @@
         author_unstem_search^40
         subject_topic_unstem_search^18
         subject_unstem_search^15
+        siku_subject_unstem_search^15
         subject_topic_index^12
+        genre_unstem_search^10
         subject_t^10
         subject_addl_unstem_search^8
         subject_addl_t^4
@@ -279,6 +281,7 @@
         text
         description_t
         cjk_all
+        cjk_text
       </str>
       <str name="pf">
         title_245a_lr^16000
@@ -290,7 +293,9 @@
         author_unstem_search^400
         subject_topic_unstem_search^180
         subject_unstem_search^150
+        siku_subject_unstem_search^150
         subject_topic_index^120
+        genre_unstem_search^100
         subject_t^100
         subject_addl_unstem_search^80
         subject_addl_t^40
@@ -300,6 +305,7 @@
         text^10
         description_t^10
         cjk_all^10
+        cjk_text^10
       </str>
       <str name="author_qf">
         author_main_unstem_search^20
@@ -343,10 +349,12 @@
       <str name="notes_qf">
         notes_index
         cjk_notes
+        cjk_notes_copied
       </str>
       <str name="notes_pf">
         notes_index
         cjk_notes
+        cjk_notes_copied
       </str>
       <str name="series_title_qf">
         series_title_index^5
@@ -407,11 +415,15 @@
       <str name="subject_qf">
         subject_topic_unstem_search^25
         subject_unstem_search^20
+        genre_unstem_search^15
+        siku_subject_unstem_search
         cjk_subject
       </str>
       <str name="subject_pf">
         subject_topic_unstem_search^250
         subject_unstem_search^200
+        genre_unstem_search^150
+        siku_subject_unstem_search^10
         cjk_subject^10
       </str>
 


### PR DESCRIPTION
Uses `catalog-production-alt` by default in the rake task to update Solr config files since we are moving away from `catalog-production`

Updated Solr config files with current version of files in `catalog-production-alt` in pul_solr.