### PR TITLE
Refactor get_items_for_bib to return the BibItemSet and add a filter option to BibItemSet#holdings_summary

### DIFF
--- a/app/adapters/alma_adapter.rb
+++ b/app/adapters/alma_adapter.rb
@@ -43,8 +43,8 @@ class AlmaAdapter
   # @return [AlmaAdapter::BibItemSet]
   def get_items_for_bib(id)
     opts = { limit: 100, expand: "due_date_policy,due_date", order_by: "library", direction: "asc" }
-    bib_item_set = Alma::BibItem.find(id, opts).map { |item| AlmaAdapter::AlmaItem.new(item) }
-    AlmaAdapter::BibItemSet.new(items: bib_item_set, adapter: self)
+    bib_items = Alma::BibItem.find(id, opts).map { |item| AlmaAdapter::AlmaItem.new(item) }
+    AlmaAdapter::BibItemSet.new(items: bib_items, adapter: self)
   end
 
   # @param record [AlmaAdapter::MarcRecord]

--- a/app/adapters/alma_adapter.rb
+++ b/app/adapters/alma_adapter.rb
@@ -40,12 +40,11 @@ class AlmaAdapter
   end
 
   # @param id [String]. e.g id = "991227850000541"
-  # @return [Hash] of locations/ holdings/ items data
+  # @return [AlmaAdapter::BibItemSet]
   def get_items_for_bib(id)
     opts = { limit: 100, expand: "due_date_policy,due_date", order_by: "library", direction: "asc" }
     bib_item_set = Alma::BibItem.find(id, opts).map { |item| AlmaAdapter::AlmaItem.new(item) }
-    bib_item_set = AlmaAdapter::BibItemSet.new(items: bib_item_set, adapter: self)
-    bib_item_set.holding_summary
+    AlmaAdapter::BibItemSet.new(items: bib_item_set, adapter: self)
   end
 
   # @param record [AlmaAdapter::MarcRecord]
@@ -57,7 +56,7 @@ class AlmaAdapter
     if ava.count > 0
       # Get the creation date from the physical items
       dates = []
-      get_items_for_bib(record.bib.id).each do |_location, holdings|
+      get_items_for_bib(record.bib.id).holding_summary.each do |_location, holdings|
         items = holdings.map { |h| h["items"] }.compact.flatten
         dates += items.map { |i| i["creation_date"] }.compact.flatten
       end

--- a/app/adapters/alma_adapter.rb
+++ b/app/adapters/alma_adapter.rb
@@ -55,11 +55,8 @@ class AlmaAdapter
     ava = record.select { |f| f.tag == "AVA" }
     if ava.count > 0
       # Get the creation date from the physical items
-      dates = []
-      get_items_for_bib(record.bib.id).holding_summary.each do |_location, holdings|
-        items = holdings.map { |h| h["items"] }.compact.flatten
-        dates += items.map { |i| i["creation_date"] }.compact.flatten
-      end
+      item_set = get_items_for_bib(record.bib.id)
+      dates = item_set.items.map { |i| i["item_data"]["creation_date"] }
       return dates.sort.first if dates.count > 0
     end
 

--- a/app/adapters/alma_adapter.rb
+++ b/app/adapters/alma_adapter.rb
@@ -56,7 +56,7 @@ class AlmaAdapter
     if ava.count > 0
       # Get the creation date from the physical items
       item_set = get_items_for_bib(record.bib.id)
-      dates = item_set.items.map { |i| i["item_data"]["creation_date"] }
+      dates = item_set.items.map { |i| i["item_data"]["creation_date"] }.compact
       return dates.sort.first if dates.count > 0
     end
 

--- a/app/adapters/alma_adapter/bib_item_set.rb
+++ b/app/adapters/alma_adapter/bib_item_set.rb
@@ -19,7 +19,7 @@ class AlmaAdapter
 
     # minimal summary of locations / holdings / items data used for bib_items
     # response
-    # @param [String] item_key_filter Keys to include in the items hash
+    # @param item_key_filter [String] keys to include in the items hash
     # @return [Hash] of locations/ holdings/ items data
     def holding_summary(item_key_filter: nil)
       location_grouped = items.group_by(&:composite_location)
@@ -37,11 +37,11 @@ class AlmaAdapter
 
     private
 
-      def holding_items_filter(items, keys)
-        return items unless keys
+      def holding_items_filter(items, filter)
+        return items unless filter
         items.map do |h|
           h.keep_if do |k, _v|
-            keys.include? k
+            filter.include? k
           end
         end
       end

--- a/app/controllers/bibliographic_controller.rb
+++ b/app/controllers/bibliographic_controller.rb
@@ -93,10 +93,10 @@ class BibliographicController < ApplicationController
 
   def bib_items
     item_keys = ["id", "pid", "perm_location", "temp_location"]
-    records = adapter.get_items_for_bib(bib_id_param).holding_summary(item_key_filter: item_keys)
+    holding_summary = adapter.get_items_for_bib(bib_id_param).holding_summary(item_key_filter: item_keys)
 
     respond_to do |wants|
-      wants.json  { render json: MultiJson.dump(add_locator_call_no(records)) }
+      wants.json  { render json: MultiJson.dump(add_locator_call_no(holding_summary)) }
       wants.xml { render xml: '<todo but="You probably want JSON anyway" />' }
     end
   rescue Alma::BibItemSet::ResponseError

--- a/app/controllers/bibliographic_controller.rb
+++ b/app/controllers/bibliographic_controller.rb
@@ -94,14 +94,17 @@ class BibliographicController < ApplicationController
   def bib_items
     item_keys = ["id", "pid", "perm_location", "temp_location"]
     records = adapter.get_items_for_bib(bib_id_param).holding_summary(item_key_filter: item_keys)
-    if records.nil? || records.empty?
-      render plain: "Record #{params[:bib_id]} not found or suppressed", status: 404
-    else
-      respond_to do |wants|
-        wants.json  { render json: MultiJson.dump(add_locator_call_no(records)) }
-        wants.xml { render xml: '<todo but="You probably want JSON anyway" />' }
-      end
+
+    respond_to do |wants|
+      wants.json  { render json: MultiJson.dump(add_locator_call_no(records)) }
+      wants.xml { render xml: '<todo but="You probably want JSON anyway" />' }
     end
+  rescue Alma::BibItemSet::ResponseError
+    render_not_found(params[:bib_id])
+  end
+
+  def render_not_found(id)
+    render plain: "Record #{id} not found or suppressed", status: 404
   end
 
   def update

--- a/app/controllers/bibliographic_controller.rb
+++ b/app/controllers/bibliographic_controller.rb
@@ -92,7 +92,8 @@ class BibliographicController < ApplicationController
   end
 
   def bib_items
-    records = adapter.get_items_for_bib(bib_id_param)
+    item_keys = ["id", "pid", "perm_location", "temp_location"]
+    records = adapter.get_items_for_bib(bib_id_param).holding_summary(item_key_filter: item_keys)
     if records.nil? || records.empty?
       render plain: "Record #{params[:bib_id]} not found or suppressed", status: 404
     else
@@ -232,6 +233,7 @@ class BibliographicController < ApplicationController
     end
 
     def add_locator_call_no(records)
+      return records unless records["f"]
       records["f"] = records["f"].map do |record|
         record[:sortable_call_number] = sortable_call_number(record[:call_number])
         record

--- a/spec/adapters/alma_adapter/alma_item_spec.rb
+++ b/spec/adapters/alma_adapter/alma_item_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe AlmaAdapter::AlmaItem do
       end
     end
   end
+
   describe "#group_designation" do
     ['pa', 'gp', 'qk', 'pf'].each do |code|
       context "when location is #{code}" do
@@ -58,6 +59,7 @@ RSpec.describe AlmaAdapter::AlmaItem do
       end
     end
   end
+
   describe "#recap_use_restriction" do
     ["pj", "pk", "pl", "pm", "pn", "pt"].each do |code|
       context "when location is #{code}" do

--- a/spec/adapters/alma_adapter/bib_item_set_spec.rb
+++ b/spec/adapters/alma_adapter/bib_item_set_spec.rb
@@ -6,4 +6,42 @@ RSpec.describe AlmaAdapter::BibItemSet do
     bib_item_set = described_class.new(items: items, adapter: nil)
     expect(bib_item_set.all? { |s| s.recap_status == "Not Used" }).to be true
   end
+
+  describe "#holding_summary" do
+    let(:alma_item) do
+      AlmaAdapter::AlmaItem.new(
+        Alma::BibItem.new(
+          "item_data" => {
+            "pid" => "23201851070006421",
+            "barcode" => "32101097382343",
+            "library" => { "value" => "firestone", "desc" => "Firestone Library" },
+            "location" => { "value" => "stacks", "desc" => "Firestone Library" },
+            "policy" => {},
+            "creation_date" => "2020-12-02Z"
+          },
+          "holding_data" => {
+            "holding_id" => "22201851080006421",
+            "call_number" => "HD6331 .H88 2018"
+          }
+        )
+      )
+    end
+
+    it "formats the item list as a hash of locations / holdings / items data" do
+      set = described_class.new(items: [alma_item], adapter: nil)
+      holding = set.holding_summary["firestone$stacks"].first
+      expect(holding.keys).to contain_exactly("holding_id", "call_number", "items")
+      expect(holding["holding_id"]).to eq "22201851080006421"
+      expect(holding["call_number"]).to eq "HD6331 .H88 2018"
+      item = holding["items"].first
+      expect(item.keys).to include("id", "pid", "perm_location", "temp_location", "creation_date")
+    end
+
+    it "filters to specific item keys if provided" do
+      set = described_class.new(items: [alma_item], adapter: nil)
+      summary = set.holding_summary(item_key_filter: ["perm_location"])
+      item = summary["firestone$stacks"].first["items"].first
+      expect(item.keys).to contain_exactly("perm_location")
+    end
+  end
 end

--- a/spec/adapters/alma_adapter_spec.rb
+++ b/spec/adapters/alma_adapter_spec.rb
@@ -141,11 +141,14 @@ RSpec.describe AlmaAdapter do
   end
 
   describe "#get_items_for_bib" do
-    context "A record with order information" do
+    context "A record with one location" do
       it "has all the relevant item keys" do
-        item = adapter.get_items_for_bib(bib_items_po)["MAIN$main"].first["items"].first
+        locations = adapter.get_items_for_bib(bib_items_po)
+        expect(locations.count).to eq 1
+        items = locations["MAIN$main"].first["items"]
+        expect(items.count).to eq 1
 
-        expect(item.keys).to contain_exactly("id", "pid", "perm_location", "temp_location", "creation_date")
+        item = items.first
         expect(item["id"]).to eq "2384011050006421"
         expect(item["pid"]).to eq "2384011050006421"
         expect(item["perm_location"]).to eq "MAIN$main"

--- a/spec/controllers/bibliographic_controller_spec.rb
+++ b/spec/controllers/bibliographic_controller_spec.rb
@@ -248,14 +248,11 @@ RSpec.describe BibliographicController, type: :controller do
       end
     end
 
+    # a bound-with constituent item will have this response
     context 'when no items are found' do
-      before do
-        # allow(VoyagerHelpers::Liberator).to receive(:get_items_for_bib).and_return(nil)
-      end
-
       it 'renders a 404 HTTP response' do
-        pending "Replace with Alma"
-        get :bib_items, params: { bib_id: '1234567' }, format: 'json'
+        stub_alma_bib_items(mms_id: "9920809213506421", status: 400, filename: "not_found_items.json")
+        get :bib_items, params: { bib_id: '9920809213506421' }, format: 'json'
         expect(response.status).to be 404
       end
     end

--- a/spec/controllers/bibliographic_controller_spec.rb
+++ b/spec/controllers/bibliographic_controller_spec.rb
@@ -188,6 +188,36 @@ RSpec.describe BibliographicController, type: :controller do
   end
 
   describe '#bib_items' do
+    context "A record with one location" do
+      let(:bib_items_po) { "99227515106421" }
+      before do
+        stub_alma_bib_items(mms_id: bib_items_po, filename: "#{bib_items_po}_po.json")
+      end
+
+      it "has the exact required keys, values" do
+        get :bib_items, params: { bib_id: bib_items_po }, format: 'json'
+
+        expect(response.status).to be 200
+        locations = JSON.parse(response.body)
+
+        expected_response = {
+          "MAIN$main" => [
+            { "holding_id" => "2284011070006421",
+              "call_number" => "PN1993.I",
+              "items" => [
+                { "pid" => "2384011050006421",
+                  "id" => "2384011050006421",
+                  # "patron_group_charged" => nil, # TODO: Implement
+                  "temp_location" => nil,
+                  "perm_location" => "MAIN$main" }
+              ] }
+          ]
+        }
+
+        expect(locations).to eq expected_response
+      end
+    end
+
     context 'when call number is not handeled by lcsort' do
       before do
         # allow(VoyagerHelpers::Liberator).to receive(:get_items_for_bib).and_return(

--- a/spec/controllers/bibliographic_controller_spec.rb
+++ b/spec/controllers/bibliographic_controller_spec.rb
@@ -190,17 +190,8 @@ RSpec.describe BibliographicController, type: :controller do
   describe '#bib_items' do
     context "A record with one location" do
       let(:bib_items_po) { "99227515106421" }
-      before do
-        stub_alma_bib_items(mms_id: bib_items_po, filename: "#{bib_items_po}_po.json")
-      end
-
-      it "has the exact required keys, values" do
-        get :bib_items, params: { bib_id: bib_items_po }, format: 'json'
-
-        expect(response.status).to be 200
-        locations = JSON.parse(response.body)
-
-        expected_response = {
+      let(:expected_response) do
+        {
           "MAIN$main" => [
             { "holding_id" => "2284011070006421",
               "call_number" => "PN1993.I",
@@ -213,8 +204,74 @@ RSpec.describe BibliographicController, type: :controller do
               ] }
           ]
         }
+      end
 
+      it "has the exact required keys, values" do
+        stub_alma_bib_items(mms_id: bib_items_po, filename: "#{bib_items_po}_po.json")
+        get :bib_items, params: { bib_id: bib_items_po }, format: 'json'
+        expect(response.status).to be 200
+        locations = JSON.parse(response.body)
         expect(locations).to eq expected_response
+      end
+    end
+
+    context "A record with two locations, two items in each location" do
+      let(:unsuppressed_two_loc_two_items) { "99223608406421" }
+      let(:fixture) { "#{unsuppressed_two_loc_two_items}_two_locations_two_items.json" }
+      let(:expected_response) do
+        {
+          "MAIN$RESERVES" => [
+            { "call_number" => "Q175 .N3885 1984", "holding_id" => "2282241690006421", "items" => [
+              { "id" => "2382260850006421", "perm_location" => "MAIN$RESERVES", "pid" => "2382260850006421", "temp_location" => nil },
+              { "id" => "2382241620006421", "perm_location" => "MAIN$RESERVES", "pid" => "2382241620006421", "temp_location" => nil }
+            ] }
+          ],
+          "MAIN$offsite" => [
+            { "call_number" => "Q175 .N3885 1984", "holding_id" => "2282241870006421", "items" => [
+              { "id" => "2382260930006421", "perm_location" => "MAIN$offsite", "pid" => "2382260930006421", "temp_location" => nil },
+              { "id" => "2382241780006421", "perm_location" => "MAIN$offsite", "pid" => "2382241780006421", "temp_location" => nil }
+            ] }
+          ]
+        }
+      end
+      it "returns a hash with 2 locations" do
+        stub_alma_bib_items(mms_id: unsuppressed_two_loc_two_items, filename: fixture)
+        get :bib_items, params: { bib_id: unsuppressed_two_loc_two_items }, format: 'json'
+        expect(response.status).to be 200
+        locations = JSON.parse(response.body)
+        expect(locations).to eq expected_response
+      end
+    end
+
+    context "A record with two locations and two different holdings in one location" do
+      let(:unsuppressed_loc_with_two_holdings) { "99229556706421" }
+      let(:fixture) { "#{unsuppressed_loc_with_two_holdings}_two_loc_two_holdings_sort_library_asc.json" }
+      let(:expected_response) do
+        {
+          "MAIN$main" => [{ "call_number" => "HG2491 .S65 1996", "holding_id" => "2284629920006421", "items" => [{ "id" => "2384629900006421", "perm_location" => "MAIN$main", "pid" => "2384629900006421", "temp_location" => nil }, { "id" => "2384621860006421", "perm_location" => "MAIN$main", "pid" => "2384621860006421", "temp_location" => nil }] }, { "call_number" => "HG2491 .S65 1996 c. 3", "holding_id" => "2284621880006421", "items" => [{ "id" => "2384621850006421", "perm_location" => "MAIN$main", "pid" => "2384621850006421", "temp_location" => nil }, { "id" => "2384621840006421", "perm_location" => "MAIN$main", "pid" => "2384621840006421", "temp_location" => nil }] }],
+          "MUS$music" => [{ "call_number" => "HG2491 .S65 1996", "holding_id" => "2284621870006421", "items" => [{ "id" => "2384621830006421", "perm_location" => "MUS$music", "pid" => "2384621830006421", "temp_location" => nil }, { "id" => "2384621820006421", "perm_location" => "MUS$music", "pid" => "2384621820006421", "temp_location" => nil }] }]
+        }
+      end
+
+      it "returns the locations, holdings, and items JSON" do
+        stub_alma_bib_items(mms_id: unsuppressed_loc_with_two_holdings, filename: fixture)
+        get :bib_items, params: { bib_id: unsuppressed_loc_with_two_holdings }, format: 'json'
+        expect(response.status).to be 200
+        locations = JSON.parse(response.body)
+        expect(locations).to eq expected_response
+      end
+    end
+
+    context "when a record has holdings with a temporary location" do
+      let(:bib_items) { "9930766283506421" }
+      let(:fixture) { "#{bib_items}_items.json" }
+
+      it "returns holdings item with a temp location value" do
+        stub_alma_bib_items(mms_id: bib_items, filename: fixture)
+        get :bib_items, params: { bib_id: bib_items }, format: 'json'
+        expect(response.status).to be 200
+        locations = JSON.parse(response.body)
+        expect(locations["online$etasrcp"][0]["items"][0]["temp_location"]).to eq "online$etasrcp"
       end
     end
 

--- a/spec/fixtures/files/alma/not_found_items.json
+++ b/spec/fixtures/files/alma/not_found_items.json
@@ -1,0 +1,1 @@
+{"total_record_count":0}

--- a/spec/support/stub_alma.rb
+++ b/spec/support/stub_alma.rb
@@ -11,11 +11,11 @@ module AlmaStubbing
       .to_return(status: status, body: all_items_path, headers: { 'Content-Type' => 'application/json' })
   end
 
-  def stub_alma_bib_items(mms_id:, filename:)
+  def stub_alma_bib_items(mms_id:, status: 200, filename:)
     alma_path = Pathname.new(file_fixture_path).join("alma")
     stub_request(:get, "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/#{mms_id}/holdings/ALL/items?expand=due_date_policy,due_date&order_by=library&direction=asc&limit=100")
       .to_return(
-        status: 200,
+        status: status,
         headers: { "content-Type" => "application/json" },
         body: alma_path.join(filename)
       )

--- a/spec/support/stub_alma.rb
+++ b/spec/support/stub_alma.rb
@@ -11,6 +11,16 @@ module AlmaStubbing
       .to_return(status: status, body: all_items_path, headers: { 'Content-Type' => 'application/json' })
   end
 
+  def stub_alma_bib_items(mms_id:, filename:)
+    alma_path = Pathname.new(file_fixture_path).join("alma")
+    stub_request(:get, "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/#{mms_id}/holdings/ALL/items?expand=due_date_policy,due_date&order_by=library&direction=asc&limit=100")
+      .to_return(
+        status: 200,
+        headers: { "content-Type" => "application/json" },
+        body: alma_path.join(filename)
+      )
+  end
+
   def stub_alma_holding(mms_id:, holding_id:)
     alma_path = Pathname.new(file_fixture_path).join("alma")
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/#{mms_id}\/holdings\/#{holding_id}$/)


### PR DESCRIPTION
This moves the logic of which keys are returned directly to the controller, and allows simplified logic in get_catalog_date_for_record

closes #1119 